### PR TITLE
fix: broken link in OpenFGA chart README

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "v0.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/README.md
+++ b/charts/openfga/README.md
@@ -15,7 +15,7 @@ $ helm repo add openfga https://openfga.github.io/helm-charts
 $ helm install openfga openfga/openfga
 ```
 
-This will deploy a 3-replica deployment of OpenFGA on the Kubernetes cluster using the default configurations for OpenFGA. For more information on the default values, please see the official [OpenFGA documentation](https://openfga.dev/docs/getting-started/setup-openfga#configuring-the-server). The [Parameters](#parameters) section below lists the parameters that can be configured during installation.
+This will deploy a 3-replica deployment of OpenFGA on the Kubernetes cluster using the default configurations for OpenFGA. For more information on the default values, please see the official [OpenFGA documentation](https://openfga.dev/docs/getting-started/setup-openfga/docker#configuring-the-server). The [Parameters](#parameters) section below lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fix a broken link in the OpenFGA chart README, and bump the chart version to force Artifact Hub to update the README for the package.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
