### PR TITLE
fix: prefix job-status-reader role and binding with helm release

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "v0.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/rbac.yaml
+++ b/charts/openfga/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: job-status-reader
+  name: {{ include "openfga.fullname" . }}-job-status-reader
 rules:
 - apiGroups:
   - batch
@@ -14,11 +14,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: job-status-reader
+  name: {{ include "openfga.fullname" . }}-job-status-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: job-status-reader
+  name: {{ include "openfga.fullname" . }}-job-status-reader
 subjects:
 - kind: ServiceAccount
   name: {{ include "openfga.serviceAccountName" . }}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This prefixes the `job-status-reader` role and rolebinding resource with the Helm release name so that separate helm releases don't collide.

To test this out you can do the following:
```
helm install goofyparrot openfga/openfga
helm install goofyparrot2 openfga/openfga # this will fail because of the collision
```
then run it with these changes instead
```
git clone <this-repo>
git checkout fix-jobstatusreader-resource
cd <this-repo>
helm install goofyparrot ./charts/openfga
helm install goofyparrot2 ./charts/openfga # this will succeed
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
