### PR TITLE
fix: testListObject env variable as string

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "v0.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"

--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -35,7 +35,7 @@ spec:
     {{- end }}
     {{- if .Values.testListObject }}
     - name: "TEST_LIST_OBJECT"
-      value: {{ .Values.testListObject }}
+      value: "{{ .Values.testListObject }}"
     {{- end }}
     - name: K6_CLOUD_PROJECT_ID
       value: "{{ .Values.k6.projectID }}"


### PR DESCRIPTION

## Description
testListObject needs to be treated as string prior to being set as environment variable

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
