### PR TITLE
feat: configurable k6 setup timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .vscode
 /charts/*/charts
+.github/workflows/*.tgz

--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "v0.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"

--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -4,7 +4,7 @@ description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benc
 
 type: application
 version: 0.0.4
-appVersion: "v0.4.2"
+appVersion: "v0.4.3"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"
 icon: https://github.com/openfga/community/raw/main/brand-assets/icon/color/openfga-icon-color.svg

--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -45,7 +45,7 @@ spec:
           name: "{{ .Values.k6.secretKeyName }}"
           key: "{{ .Values.k6.secretKeyToken }}"
     - name: K6_SETUP_TIMEOUT
-      value: "{{ .values.setupTimeout }}"
+      value: "{{ .values.k6.setupTimeoutInSeconds }}"
   volumes:
   - name: benchmark-script
     configMap:

--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -44,6 +44,8 @@ spec:
         secretKeyRef:
           name: "{{ .Values.k6.secretKeyName }}"
           key: "{{ .Values.k6.secretKeyToken }}"
+    - name: K6_SETUP_TIMEOUT
+      value: "{{ .values.setupTimeout }}"
   volumes:
   - name: benchmark-script
     configMap:

--- a/charts/benchmark/values.yaml
+++ b/charts/benchmark/values.yaml
@@ -2,6 +2,7 @@ k6:
   projectID:
   secretKeyName: k6-cloud-token
   secretKeyToken: token
+  setupTimeoutInSeconds: 1200
 
 Nparam: 1
 Mparam: 1
@@ -9,4 +10,3 @@ Kparam: 1
 testCase: 1
 testCheck: true
 testListObject: false
-setupTimeout: 1200

--- a/charts/benchmark/values.yaml
+++ b/charts/benchmark/values.yaml
@@ -9,3 +9,4 @@ Kparam: 1
 testCase: 1
 testCheck: true
 testListObject: false
+setupTimeout: 1200


### PR DESCRIPTION

## Description
Add configurable k6 setup timeout.


## References
Close https://github.com/openfga/helm-charts/issues/14

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
