### PR TITLE
chore: update default timeout value

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "v0.4.3"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"

--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -45,7 +45,7 @@ spec:
           name: "{{ .Values.k6.secretKeyName }}"
           key: "{{ .Values.k6.secretKeyToken }}"
     - name: K6_SETUP_TIMEOUT
-      value: "{{ .Values.k6.setupTimeoutInSeconds }}"
+      value: "{{ .Values.k6.setupTimeoutInMs }}"
   volumes:
   - name: benchmark-script
     configMap:

--- a/charts/benchmark/values.yaml
+++ b/charts/benchmark/values.yaml
@@ -2,7 +2,7 @@ k6:
   projectID:
   secretKeyName: k6-cloud-token
   secretKeyToken: token
-  setupTimeoutInSeconds: 1200
+  setupTimeoutInMs: 1200000
 
 Nparam: 1
 Mparam: 1


### PR DESCRIPTION

## Description
Tweak default k6 timeout value.  Also note that time is in ms, not in seconds - thus we should rename variable to fit the actual description.

## References
N/A

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
