### PR TITLE
fix: update path of grpc_health_probe as it was changed in OpenFGA v1.0.1

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -272,7 +272,7 @@ spec:
 
           readinessProbe:
             exec:
-              command: ["/bin/grpc_health_probe", "-addr={{ .Values.grpc.addr }}"]
+              command: ["grpc_health_probe", "-addr={{ .Values.grpc.addr }}"]
             initialDelaySeconds: 5
 
           resources:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Thanks to @alee792 for spotting the issue: https://github.com/openfga/helm-charts/pull/21#issuecomment-1513712717

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- https://github.com/openfga/openfga/pull/697

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
