### PR TITLE
feat(benchmark): add configuration for num tuples per write

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"

--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -29,6 +29,10 @@ spec:
       value: "{{ .Values.Kparam }}"
     - name: "TEST_CASE"
       value: "{{ .Values.testCase }}"
+    - name: "TUPLES_PER_WRITE"
+      value: "{{ .Values.tuplesPerWrite }}"
+    - name: "POSITION"
+      value: "{{ .Values.tuplesPosition }}"
     {{- if .Values.testCheck }}
     - name: "TEST_CHECK"
       value: "{{ .Values.testCheck }}"

--- a/charts/benchmark/values.yaml
+++ b/charts/benchmark/values.yaml
@@ -10,3 +10,5 @@ Kparam: 1
 testCase: 1
 testCheck: true
 testListObject: false
+tuplesPerWrite: 100
+tuplesPosition: start


### PR DESCRIPTION

## Description
Allow configuration on benchmark for number of tuples per write and which user we want to run check/list objects on

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
