### PR TITLE
feat: specify a secret for the datastore URI

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -74,6 +74,12 @@ spec:
             {{- if .Values.datastore.uri }}
             - name: OPENFGA_DATASTORE_URI
               value: "{{ .Values.datastore.uri }}"
+            {{- else if .Values.datastore.uriSecret }}
+            - name: OPENFGA_DATASTORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.uriSecret }}"
+                  key: "uri"
             {{- end }}
 
             {{- if .Values.datastore.maxCacheSize }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -61,6 +61,10 @@
                 "uri": {
                     "type":["string", "null"]
                 },
+                "uriSecret": {
+                    "type":["string", "null"],
+                    "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
+                },
                 "maxCacheSize": {
                     "type": ["integer", "null"],
                     "description": "the maximum number of cache keys that the storage cache can store before evicting old keys"

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -63,6 +63,7 @@ telemetry:
 datastore:
   engine: memory
   uri:
+  uriSecret:
   maxCacheSize:
   maxOpenConns:
   maxIdleConns: 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Allow specifying a secret for the datastore URI.

## Description

In some environments, it might be unfeasible to include the datastore URI in plaintext within the Helm values specified. An example would be using an external Database and wanting to keep the secrets of that database outside the Git repo where the project is deployed.

To address this, I'm adding an option where an external secret can be referenced, and instead of specifying the URI directly in the deployment file, the deployment will instead refer to that secret.

This allows the URI to be populated independently of the chart itself and provisioned securely.

Example:

```yaml
# values.yml

datastore:
  uriSecret: openfga-datastore
```

Resulting deployment snippet:

```yaml
...
  - name: OPENFGA_DATASTORE_URI
    valueFrom:
      secretKeyRef:
        name: openfga-datastore
        key: uri
...
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

#26 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
