### PR TITLE
fix(openfga): allow migration without embedded db

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if or .Values.postgres.enabled .Values.mysql.enabled }}
+      {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
       initContainers:
         - name: wait-for-migration
           image: groundnuty/k8s-wait-for:v1.6

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.postgres.enabled .Values.mysql.enabled -}}
+{{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -88,6 +88,11 @@
                     "description": "the maximum amount of time (as a duration) a connection to the datastore may be reused",
                     "format": "duration",
                     "examples": ["30s", "1m", "200ms"]
+                },
+                "applyMigrations": {
+                    "type": "boolean",
+                    "description": "enable/disable the job that runs migrations in the datastore",
+                    "default": false
                 }
             }
         },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -69,6 +69,7 @@ datastore:
   maxIdleConns: 
   connMaxIdleTime:
   connMaxLifetime:
+  applyMigrations: false
 
 postgres:
   ## @param postgres.enabled enable the bitnami/postgresql subchart and deploy Postgres


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

This addresses issue #28, by decoupling the migration execution from the embedded database.

## Description

Instead of deciding if the migration is run on whether `postgres.enabled` or `mysql.enabled`, that would involve the creation of the database within Kubernetes, decide the migration based on the engine defined in the datastore, by checking the value of `datastore.engine`.

That way, whenever the data store engine is one that requires running migrations, they are automatically created and run accordingly.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

#28

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork). _(Organization accounts don't support this)_
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
