### PR TITLE
fix: increase memory assigned to k6 container

### DIFF
--- a/charts/benchmark/templates/pod.yaml
+++ b/charts/benchmark/templates/pod.yaml
@@ -10,6 +10,11 @@ spec:
   containers:
   - name: k6
     image: grafana/k6:0.43.1
+    resources:
+      requests:
+        memory: "256Mi"
+      limits:
+        memory: "512Mi"
     {{- if .Values.k6.projectID }}
     args: ["run", "--out", "cloud", "/etc/scripts/app.bundle.js"]
     {{ else }}


### PR DESCRIPTION
## Description
This change is to prevent `OOMKilled` errors in AWS EKS. In the future we can make this configurable.

## References
Not tested

