### PR TITLE
chore: release new benchmark chart version

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -3,7 +3,7 @@ name: benchmark
 description: A Kubernetes Helm chart to deploy OpenFGA and run the standard benchmark suite against it.
 
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: "v1.0.1"
 
 home: "https://openfga.github.io/helm-charts/charts/benchmark"


### PR DESCRIPTION

## Description
To fix this: https://github.com/openfga/helm-charts/actions/runs/5202120710/jobs/9383267760

```
Error: error creating GitHub release benchmark-0.0.10: POST https://api.github.com/repos/openfga/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```
