### PR TITLE
fix: default `datastore.applyMigrations` to true for quick installs

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,8 +3,8 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.15
-appVersion: "v1.0.1"
+version: 0.1.16
+appVersion: "v1.1.0"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"
 icon: https://github.com/openfga/community/raw/main/brand-assets/icon/color/openfga-icon-color.svg

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -92,7 +92,7 @@
                 "applyMigrations": {
                     "type": "boolean",
                     "description": "enable/disable the job that runs migrations in the datastore",
-                    "default": false
+                    "default": true
                 }
             }
         },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -69,7 +69,7 @@ datastore:
   maxIdleConns: 
   connMaxIdleTime:
   connMaxLifetime:
-  applyMigrations: false
+  applyMigrations: true
 
 postgres:
   ## @param postgres.enabled enable the bitnami/postgresql subchart and deploy Postgres


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This changes the default value of the `datastore.applyMigrations` so that quick installs apply migrations by default. If you are redeploying OpenFGA or if you are rolling OpenFGA out with a pre-migrated datastore, then you can set this value to false.

## References
Fixes #42 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
