### PR TITLE
feat: Add sidecars to deployment

### DIFF
--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.6.0
-digest: sha256:5a9a3f1c32e3f901b1a3e1a4d6c9138ebcfe5f5a7424bfb95cd0787b50aff10a
-generated: "2023-07-17T13:51:15.673937-06:00"
+digest: sha256:07a7c73dbcbc44da76854a9155e679728fbb122091370b62c8c38177fb230227
+generated: "2023-07-25T19:23:02.030286-04:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "v1.2.0"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"
@@ -27,3 +27,5 @@ dependencies:
   - name: common
     version: "2.6.0"
     repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -308,6 +308,9 @@ spec:
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -31,7 +31,7 @@ spec:
                   name: "{{ .Values.datastore.uriSecret }}"
                   key: "uri"
             {{- end }}
-        {{- if .Values.migrateSidecars }}
+        {{- if .Values.migrate.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       restartPolicy: Never

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -31,6 +31,9 @@ spec:
                   name: "{{ .Values.datastore.uriSecret }}"
                   key: "uri"
             {{- end }}
+        {{- if .Values.migrateSidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       restartPolicy: Never
   backoffLimit: 1
 {{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -353,7 +353,6 @@
                 }
             }
         },
-<<<<<<< HEAD
         "livenessProbe": {
             "type": "object",
             "properties": {
@@ -473,7 +472,6 @@
             "type": "object",
             "default": null,
             "description": "Overrides the default startup probe with a custom one."
-=======
         "sidecars": {
             "type": "array",
             "description": "add additional sidecar containers to the pods",
@@ -488,7 +486,6 @@
                     "default": []
                 }
             }
->>>>>>> 445ce8a (updated based on comments)
         }
     }
 }

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -353,6 +353,7 @@
                 }
             }
         },
+<<<<<<< HEAD
         "livenessProbe": {
             "type": "object",
             "properties": {
@@ -472,6 +473,22 @@
             "type": "object",
             "default": null,
             "description": "Overrides the default startup probe with a custom one."
+=======
+        "sidecars": {
+            "type": "array",
+            "description": "add additional sidecar containers to the pods",
+            "default": []
+        },
+        "migrate": {
+            "type": "object",
+            "properties": {
+                "sidecars": {
+                    "type": "array",
+                    "description": "add additional sidecar containers to the migration job",
+                    "default": []
+                }
+            }
+>>>>>>> 445ce8a (updated based on comments)
         }
     }
 }

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -472,6 +472,7 @@
             "type": "object",
             "default": null,
             "description": "Overrides the default startup probe with a custom one."
+        },
         "sidecars": {
             "type": "array",
             "description": "add additional sidecar containers to the pods",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -222,7 +222,7 @@ tolerations: []
 
 affinity: {}
 
-# @param sidecars Add additional sidecar containers to the Keycloak pods
+# @param sidecars Add additional sidecar containers to the pods
 # Example:
 # sidecars:
 #   - name: your-image-name

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -124,7 +124,7 @@ telemetry:
       prometheus.io/port: "{{ .Values.containerPorts.prometheus }}"
 
 datastore:
-  engine: memory
+  engine: postgres
   uri:
   uriSecret:
   maxCacheSize:
@@ -232,3 +232,5 @@ affinity: {}
 #       - name: portname
 #         containerPort: 1234
 sidecars: []
+migrate:
+  sidecars: []

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -124,7 +124,7 @@ telemetry:
       prometheus.io/port: "{{ .Values.containerPorts.prometheus }}"
 
 datastore:
-  engine: postgres
+  engine: memory
   uri:
   uriSecret:
   maxCacheSize:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -221,3 +221,14 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# @param sidecars Add additional sidecar containers to the Keycloak pods
+# Example:
+# sidecars:
+#   - name: your-image-name
+#     image: your-image
+#     imagePullPolicy: Always
+#     ports:
+#       - name: portname
+#         containerPort: 1234
+sidecars: []


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Adding ability to specify sidecars in the deployment, default is none.

## References

Used example:

https://github.com/bitnami/charts/tree/main/bitnami/keycloak 

For defining sidecars, because I noticed this chart already leverages a couple other bitnami packages.

## Review Checklist
- [ X ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [  ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ X  ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
