### PR TITLE
chore: add more support for liveness and startup probes

### DIFF
--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 9.6.0
-digest: sha256:111e36cdc80a01d95036f1d410f84c5b7db0934bfbcf0863e6218986c53a3166
-generated: "2023-03-14T10:51:41.958125-06:00"
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.6.0
+digest: sha256:5a9a3f1c32e3f901b1a3e1a4d6c9138ebcfe5f5a7424bfb95cd0787b50aff10a
+generated: "2023-07-17T13:51:15.673937-06:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: "v1.2.0"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"
@@ -24,3 +24,6 @@ dependencies:
     version: "9.6.0"
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
+  - name: common
+    version: "2.6.0"
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -282,10 +282,29 @@ spec:
               value: "{{ .Values.telemetry.trace.sampleRatio }}"
             {{- end }}
 
-          readinessProbe:
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: ["grpc_health_probe", "-addr={{ .Values.grpc.addr }}"]
-            initialDelaySeconds: 5
+          {{- end }}
+
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+            grpc:
+              port: {{ (split ":" .Values.grpc.addr)._1 }}
+          {{- end }}
+
+          {{- if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            grpc:
+              port: {{ (split ":" .Values.grpc.addr)._1 }}
+          {{- end }}
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -352,6 +352,126 @@
                     "default": { }
                 }
             }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable liveness probes on OpenFGA containers."
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "default": 60,
+                    "description": "Number of seconds after the container has started before liveness probes are initiated."
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "default": 10,
+                    "description": "How often (in seconds) to perform the probe."
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "default": 5,
+                    "duration": "Number of seconds after which the probe times out."
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "default": 12,
+                    "description": "Failure threshold for liveness probes."
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Success threshold for liveness probes."
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable readiness probes on OpenFGA containers."
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Number of seconds after the container has started before readiness probes are initiated."
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "default": 10,
+                    "description": "How often (in seconds) to perform the probe."
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Number of seconds after which the probe times out."
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "default": 6,
+                    "description": "Failure threshold for readiness probes."
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Success threshold for readiness probes."
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable startup probes on OpenFGA containers."
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "default": 60,
+                    "description": "Number of seconds after the container has started before startup probes are initiated."
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "default": 10,
+                    "description": "How often (in seconds) to perform the probe."
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Number of seconds after which the probe times out."
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "default": 30,
+                    "description": "Failure threshold for readiness probes."
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Success threshold for readiness probes."
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "default": null,
+            "description": "Overrides the default liveness probe with a custom one."
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "default": null,
+            "description": "Overrides the default readiness probe with a custom one."
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "default": null,
+            "description": "Overrides the default startup probe with a custom one."
         }
     }
 }

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -34,6 +34,66 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+## Configure extra options for OpenFGA containers' liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+
+## @param livenessProbe.enabled Enable liveness probes on OpenFGA containers.
+## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated.
+## @param livenessProbe.periodSeconds How often (in seconds) to perform the probe.
+## @param livenessProbe.timeoutSeconds Number of seconds after which the probe times out.
+## @param livenessProbe.failureThreshold Failure threshold for liveness probes.
+## @param livenessProbe.successThreshold Success threshold for liveness probes.
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 12
+  successThreshold: 1
+
+## @param readinessProbe.enabled Enable readiness probes on OpenFGA containers.
+## @param readinessProbe.initialDelaySeconds Number of seconds after the container has started before readiness probes are initiated.
+## @param readinessProbe.periodSeconds How often (in seconds) to perform the probe.
+## @param readinessProbe.timeoutSeconds Number of seconds after which the probe times out.
+## @param readinessProbe.failureThreshold Failure threshold for readiness probes.
+## @param readinessProbe.successThreshold Success threshold for readiness probes.
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## @param startupProbe.enabled Enable startup probes on OpenFGA containers.
+## @param startupProbe.initialDelaySeconds Number of seconds after the container has started before startup probes are initiated.
+## @param startupProbe.periodSeconds How often (in seconds) to perform the probe.
+## @param startupProbe.timeoutSeconds Number of seconds after which the probe times out.
+## @param startupProbe.failureThreshold Failure threshold for startup probes.
+## @param startupProbe.successThreshold Success threshold for startup probes.
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+  successThreshold: 1
+
+## @param customLivenessProbe Overrides the default liveness probe with a custom one.
+##
+customLivenessProbe: {}
+
+## @param customReadinessProbe Overrides the default readiness probe with a custom one.
+##
+customReadinessProbe: {}
+
+## @param customStartupProbe Overrides the default startup probe with a custom one.
+##
+customStartupProbe: {}
+
 service:
   annotations: {}
   type: ClusterIP


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add default liveness and startup probes and allow custom probes to be specified for OpenFGA containers.

## References
https://github.com/orgs/openfga/discussions/172

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
