### PR TITLE
fix: Playground should disable if `playground.enabled=false`

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "v1.2.0"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -190,12 +190,10 @@ spec:
               value: {{ .Values.authn.oidc.issuer }}
             {{- end }}
 
-            {{- if .Values.playground.enabled }}
             - name: OPENFGA_PLAYGROUND_ENABLED
               value: "{{ .Values.playground.enabled }}"
             - name: OPENFGA_PLAYGROUND_PORT
               value: "{{ .Values.playground.port }}"
-            {{- end }}
 
             {{- if .Values.profiler.enabled }}
             - name: OPENFGA_PROFILER_ENABLED


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
If `playground.enabled=false` then we shouldn't omit the env variable since the Playground is enabled by default in the OpenFGA server. This makes sure that we set the env variable to true/false regardless of its value.

## References
Closes https://github.com/openfga/helm-charts/issues/54

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
