### PR TITLE
fix: allow setting `experimentals` config value

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
 
             {{- if .Values.experimentals }}
             - name: OPENFGA_EXPERIMENTALS
-              value: {{ .Values.experimentals }}
+              value: "{{ join "," .Values.experimentals }}"
             {{- end }}
 
             {{- if .Values.grpc.addr }}
@@ -126,7 +126,7 @@ spec:
             {{- if .Values.grpc.tls.enabled }}
             - name: OPENFGA_GRPC_TLS_ENABLED
               value: {{ .Values.grpc.tls.enabled }}
-            
+
             - name: OPENFGA_GRPC_TLS_CERT
               value: {{ .Values.grpc.tls.cert }}
 
@@ -150,7 +150,7 @@ spec:
 
             - name: OPENFGA_HTTP_TLS_CERT
               value: {{ .Values.http.tls.cert }}
-            
+
             - name: OPENFGA_HTTP_TLS_KEY
               value: {{ .Values.http.tls.key }}
             {{- end }}


### PR DESCRIPTION
## Description

```
helm install openfga ./charts/openfga --set experimentals='{list-objects,check-query-cache}'
```

## References

closes #57

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
