### PR TITLE
chore: generate release notes

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,2 +1,9 @@
+## Reference: https://github.com/helm/chart-releaser
+
+# PGP signing
 sign: true
 key: contact@openfga.dev
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true


### PR DESCRIPTION
## Description

Set `--generate-release-notes` to have `cr upload` use Github's automatic release notes.

## References

Closes https://github.com/openfga/helm-charts/issues/56

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
