### PR TITLE
feat: added hook to job to delete/recreate during upgrade/rollback

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.32
+version: 0.1.33
 appVersion: "v1.3.10"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end}}
   {{- with .Values.migrate.annotations }}
   annotations:
-    "helm.sh/hook": "pre-install, pre-upgrade, pre-rollback"
+    "helm.sh/hook": "pre-install, pre-upgrade, pre-rollback, pre-delete"
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
     {{- with .Values.migrate.annotations }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -13,9 +13,8 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade, post-rollback, post-delete"
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
-    {{- with .Values.migrate.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -10,8 +10,12 @@ metadata:
   {{- end}}
   {{- with .Values.migrate.annotations }}
   annotations:
+    "helm.sh/hook": "post-install, post-upgrade, post-rollback"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- with .Values.migrate.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -10,9 +10,9 @@ metadata:
   {{- end}}
   {{- with .Values.migrate.annotations }}
   annotations:
-    "helm.sh/hook": "post-install, post-upgrade, post-rollback"
+    "helm.sh/hook": "pre-install, pre-upgrade, pre-rollback"
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     {{- with .Values.migrate.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -10,9 +10,6 @@ metadata:
   {{- end}}
   {{- with .Values.migrate.annotations }}
   annotations:
-    "helm.sh/hook": "post-install, post-upgrade, post-rollback, post-delete"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end}}
   {{- with .Values.migrate.annotations }}
   annotations:
-    "helm.sh/hook": "pre-install, pre-upgrade, pre-rollback, pre-delete"
+    "helm.sh/hook": "post-install, post-upgrade, post-rollback, post-delete"
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
     {{- with .Values.migrate.annotations }}

--- a/charts/openfga/templates/rbac.yaml
+++ b/charts/openfga/templates/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - jobs
   verbs:
   - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -257,7 +257,7 @@ affinity: {}
 sidecars: []
 migrate:
   sidecars: []
-  annotations: 
+  annotations:
     helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: "before-hook-creation"

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -257,5 +257,8 @@ affinity: {}
 sidecars: []
 migrate:
   sidecars: []
-  annotations: {}
+  annotations: 
+    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: "before-hook-creation"
   labels: {}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -144,7 +144,7 @@ datastore:
     image:
       repository: groundnuty/k8s-wait-for
       pullPolicy: Always
-      tag: "v1.6"
+      tag: "v2.0"
 
 postgres:
   ## @param postgres.enabled enable the bitnami/postgresql subchart and deploy Postgres


### PR DESCRIPTION
Added annotations to the job in order for the migration job to be deleted after a successful run.

## Description

In reference to Issue #69 I've added hook annotations to the migration job in order for the job to be deleted and then recreated during a helm upgrade/rollback.

## References

For views on how to add hooks to jobs, one can reference the Helm documentation at: https://helm.sh/docs/topics/charts_hooks/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
