### PR TITLE
ci: fix failing lint-test job

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+     dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
## Description

- Add dependabot config for github actions
- Bump version for helm/chart-test

```
Run helm/chart-testing-action@v2.4.0
  with:
    version: v3.8.0
    yamllint_version: [1](https://github.com/openfga/helm-charts/pull/72/checks#step:5:1).[2](https://github.com/openfga/helm-charts/pull/72/checks#step:5:2)7.1
    yamale_version: [3](https://github.com/openfga/helm-charts/pull/72/checks#step:5:3).0.[4](https://github.com/openfga/helm-charts/pull/72/checks#step:5:4)
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.9.18/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.9.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.18/x64/lib
Run sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da8439[5](https://github.com/openfga/helm-charts/pull/72/checks#step:5:5)3c[6](https://github.com/openfga/helm-charts/pull/72/checks#step:5:6)5
Run #!/bin/bash
INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v2.0.0'
Error: Process completed with exit code 1.
```

## References

https://github.com/helm/chart-testing-action/releases/tag/v2.6.0

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
