### PR TITLE
feat: allow use of custom image for wait-for-migration initContainer

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -39,7 +39,8 @@ spec:
         - name: wait-for-migration
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: groundnuty/k8s-wait-for:v1.6
+          image: "{{ .Values.datastore.migrations.image.repository }}:{{ .Values.datastore.migrations.image.tag }}"
+          imagePullPolicy: {{ .Values.datastore.migrations.image.pullPolicy }}
           args: ["job", '{{ include "openfga.fullname" . }}-migrate']
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -141,6 +141,10 @@ datastore:
   applyMigrations: true
   migrations:
     resources: {}
+    image:
+      repository: groundnuty/k8s-wait-for
+      pullPolicy: Always
+      tag: "v1.6"
 
 postgres:
   ## @param postgres.enabled enable the bitnami/postgresql subchart and deploy Postgres


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Allow custom images to be used for the wait-for-migration initContainer. This is because we sometimes want to use private repos/images.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
