### PR TITLE
Update PostgreSQL chart to 12.12.10

### DIFF
--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 9.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.6.0
-digest: sha256:0d7f4936f6384bd7c4e08a7487c801ea9c43763d949f2fbc7014900843f50c82
-generated: "2023-12-01T14:21:56.191163+01:00"
+  version: 2.13.3
+digest: sha256:68e2cc3b60ae8e31f7749a5f1f3e7838660f6c0e2f0b40d9f5fa353afe880521
+generated: "2023-12-01T15:06:50.541713+01:00"

--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.2.3
+  version: 12.12.10
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 9.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.6.0
-digest: sha256:07a7c73dbcbc44da76854a9155e679728fbb122091370b62c8c38177fb230227
-generated: "2023-07-25T19:23:02.030286-04:00"
+digest: sha256:0d7f4936f6384bd7c4e08a7487c801ea9c43763d949f2fbc7014900843f50c82
+generated: "2023-12-01T14:21:56.191163+01:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
 
 dependencies:
   - name: postgresql
-    version: "12.2.3"
+    version: "12.12.10"
     repository: https://charts.bitnami.com/bitnami
     condition: postgres.enabled
   - name: mysql

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: common
-    version: "2.6.0"
+    version: "2.13.3"
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The current version (12.2.3) defined in Chart.yaml includes a bug in the Helm chart that's fixed with 12.5.8 and later:
* https://github.com/bitnami/charts/pull/17140
* https://github.com/bitnami/charts/commit/ffa4eeb0e853fd63fced31d1bd443c6587354f87

This PR upgrade the PostgreSQL helm chart to the latest 12.x version. I've chosen this version rather than the newest (13.2.21) because it keeps the PostgreSQL major version the same (15.x vs 16.x). I'm not familiar enough with OpenFGA to say if PostgreSQL 16 (released 14.09.2023) is already supported.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
