### PR TITLE
feat: allow migration jobs to be cleaned up after finishing

### DIFF
--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.datastore.migrateJobTtlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.datastore.migrateJobTtlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.migrate.annotations }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -99,6 +99,10 @@
                     "format": "duration",
                     "examples": ["30s", "1m", "200ms"]
                 },
+                "migrateJobTtlSecondsAfterFinished": {
+                    "type": ["integer", "null"],
+                    "description": "the number of seconds to wait after the job completes before the job is marked for cleanup (deleted cascadingly)"
+                },
                 "applyMigrations": {
                     "type": "boolean",
                     "description": "enable/disable the job that runs migrations in the datastore",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -138,6 +138,7 @@ datastore:
   maxIdleConns:
   connMaxIdleTime:
   connMaxLifetime:
+  migrateJobTtlSecondsAfterFinished:
   applyMigrations: true
   migrations:
     resources: {}


### PR DESCRIPTION
## Description
The datastore migration job that runs does not clean up after itself by default. This PR adds an optional field `.datastore.migrateJobTtlSecondsAfterFinished` that allows the job to be cleaned up after the specified time (in seconds) by the k8s ttl controller.

For our team's purposes this also allows us to have repeatable helm deployments in CI so that new jobs do not conflict with the old ones by name, seen in this error for reference: 
```Error: UPGRADE FAILED: cannot patch "appName-openfga-migrate" with kind Job: Job.batch "appName-openfga-migrate" is invalid:...```

## References
From k8s docs: https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

(I could not find documentation besides schema descriptors nor tests for these fields - please let me know if they exist and I will update accordingly)
