### PR TITLE
bump appVersion to 1.4.2

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,8 +3,8 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.32
-appVersion: "v1.3.10"
+version: 0.1.33
+appVersion: "v1.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"
 icon: https://github.com/openfga/community/raw/main/brand-assets/icon/color/openfga-icon-color.svg


### PR DESCRIPTION
## Description
Bump after recent openfga release.

## References
https://github.com/openfga/openfga/releases/tag/v1.4.2
