### PR TITLE
feat: add parameters to allow migrate job to use its own database account and service account

### DIFF
--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -62,6 +62,28 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the service account to use for the migration job
+*/}}
+{{- define "openfga.migrationServiceAccountName" -}}
+{{- if .Values.migrate.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- else if .Values.migrate.serviceAccount.create }}
+{{- default (printf "%s-%s" (include "openfga.fullname" .) "migrate") .Values.migrate.serviceAccount.name }}
+{{- else }}
+{{- include "openfga.serviceAccountName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return true if migration job is enabled
+*/}}
+{{- define "openfga.haveMigration" -}}
+{{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if a secret object should be created
 */}}
 {{- define "openfga.createSecret" -}}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations -}}
+{{- if (include "openfga.haveMigration" .) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "openfga.serviceAccountName" . }}
+      serviceAccountName: {{ include "openfga.migrationServiceAccountName" . }}
       containers:
         - name: migrate-database
           securityContext:
@@ -37,7 +37,16 @@ spec:
               value: "{{ .Values.datastore.engine }}"
             {{- end }}
 
-            {{- if .Values.datastore.uri }}
+            {{- if .Values.datastore.migrations.uri}}
+            - name: OPENFGA_DATASTORE_URI
+              value: "{{ .Values.datastore.migrations.uri }}"
+            {{- else if .Values.datastore.migrations.uriSecret }}
+            - name: OPENFGA_DATASTORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.migrations.uriSecret }}"
+                  key: "uri"
+            {{- else if .Values.datastore.uri }}
             - name: OPENFGA_DATASTORE_URI
               value: "{{ .Values.datastore.uri }}"
             {{- else if .Values.datastore.uriSecret }}
@@ -47,12 +56,25 @@ spec:
                   name: "{{ .Values.datastore.uriSecret }}"
                   key: "uri"
             {{- end }}
+            {{- if .Values.migrate.extraEnvVars }}
+            {{- toYaml .Values.migrate.extraEnvVars | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+
+          {{- with .Values.migrate.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.migrate.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
         {{- end }}
+
       restartPolicy: Never
+      {{- with .Values.migrate.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openfga/templates/serviceaccount.yaml
+++ b/charts/openfga/templates/serviceaccount.yaml
@@ -10,3 +10,23 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+---
+{{- if and (include "openfga.haveMigration" .) .Values.migrate.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openfga.migrationServiceAccountName" . }}
+  labels:
+    {{- include "openfga.labels" . | nindent 4 }}
+  {{- if .Values.migrate.serviceAccount.annotations }}
+  {{- with .Values.migrate.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else if .Values.serviceAccount.annotations -}}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -103,6 +103,46 @@
                     "type": "boolean",
                     "description": "enable/disable the job that runs migrations in the datastore",
                     "default": true
+                },
+                "migrations": {
+                    "type": "object",
+                    "description": "Additional configuration for the database migration job",
+                    "properties": {
+                        "resources": {
+                            "type": "object",
+                            "description": "Kubernetes resource requests and limits for the migration job",
+                            "default": {}
+                        },
+                        "image": {
+                            "type": "object",
+                            "description": "Image configuration for the migration job",
+                            "properties": {
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Container used to wait for migration to complete",
+                                    "default": "groundnuty/k8s-wait-for"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Image tag for the migration job",
+                                    "default": "v2.0"
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Image pull policy for the migration job",
+                                    "default": "Always"
+                                }
+                            }
+                        },
+                        "uri": {
+                            "type":["string", "null"],
+                            "description": "the datastore URI to use for migrations"
+                        },
+                        "uriSecret": {
+                            "type":["string", "null"],
+                            "description": "the secret name where to get the datastore URI for migrations, it expects a key named uri to exist in the secret"
+                        }
+                    }
                 }
             }
         },
@@ -552,6 +592,58 @@
                 "description": "Map of annotations to add to the migration job's manifest",
                 "additionalProperties": { "type": "string" },
                 "default": { }
+            },
+            "labels": {
+                "type": "object",
+                "description": "Map of labels to add to the migration job's manifest",
+                "additionalProperties": { "type": "string" },
+                "default": { }
+            },
+            "extraEnvVars": {
+                "type": "array",
+                "description": "List of additional environment variables to add to the migration job's main container",
+                "items": {
+                    "type": "object"
+                },
+                "default": []
+            },
+            "extraVolumes": {
+                "type": "array",
+                "description": "List of additional volumes to add to the migration job",
+                "items": {
+                    "type": "object"
+                },
+                "default": []
+            },
+            "extraVolumeMounts": {
+                "type": "array",
+                "description": "List of additional volumes to add to the migration job",
+                "items": {
+                    "type": "object"
+                },
+                "default": []
+            },
+            "serviceAccount": {
+                "type": "object",
+                "description": "ServiceAccount to be used for the migration job.  If create or name is not set, it uses the same service acocunt as the deployment",
+                "properties": {
+                    "create": {
+                        "type": "boolean",
+                        "description": "Whether to create a ServiceAccount for the migration job",
+                        "default": false
+                    },
+                    "annotations": {
+                        "type": "object",
+                        "description": "Annotations to add to the ServiceAccount",
+                        "additionalProperties": { "type": "string" },
+                        "default": { }
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the ServiceAccount to use.  If not set and create is true, a name is generated using the fullname template",
+                        "default": ""
+                    }
+                }
             }
         },
         "extraEnvVars": {

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -132,6 +132,8 @@ telemetry:
 datastore:
   engine: memory
   uri:
+  # A secret containing a "uri" key with the database URI to use.  Use this if you have a
+  # password in the URI (for example)
   uriSecret:
   maxCacheSize:
   maxOpenConns:
@@ -145,6 +147,11 @@ datastore:
       repository: groundnuty/k8s-wait-for
       pullPolicy: Always
       tag: "v2.0"
+    # The database URI to use for migrations.  If unset, the URI from datastore.uri is used.
+    uri:
+    # A secret containing a "uri" key with the database URI to use for migrations.  Use this
+    # if you have a password in the URI (for example).
+    uriSecret:
 
 postgres:
   ## @param postgres.enabled enable the bitnami/postgresql subchart and deploy Postgres
@@ -262,3 +269,15 @@ migrate:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: "before-hook-creation"
   labels: {}
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  serviceAccount:
+    # Specifies whether a separate migration service account should be created
+    create: false
+    # Annotations to add to the migration service account.  If unset, the annotations
+    # from serviceAccount.annotations are used.
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""


### PR DESCRIPTION
Fixes #95

## Description
Add parameters to enable running the migration job with a different database access level.
- We are using [AWS RDS IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.AWSCLI.PostgreSQL.html) using a sidecar to populate a `PGPASSFILE` file with credentials (which rotate every 15 minutes).
- This means we need:
  - A separate database URI (for a different database user with schema-change permissions)
  - A separate service account (for an independent IAM role assignment for the migration job)
  - Separate sidecar, volumes, and volumeMounts to be able to share a 1MB shared in-memory volume between the sidecar and the migration process
  - The ability to set `PGPASSFILE` in the migration container

## References
- https://github.com/openfga/helm-charts/issues/95
- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html

(Unfortunately, our other examples of doing this aren't public)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
