### PR TITLE
feat: Add flag to wait for migrations to complete (or not)

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.35
+version: 0.1.36
 appVersion: "v1.4.3"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
+      {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations .Values.datastore.waitForMigrations }}
       initContainers:
         - name: wait-for-migration
           securityContext:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -268,6 +268,11 @@
                     "type": "boolean",
                     "description": "enable/disable the job that runs migrations in the datastore",
                     "default": true
+                },
+                "waitForMigrations": {
+                    "type": "boolean",
+                    "description": "wait for migrations to complete before starting the server",
+                    "default": true
                 }
             }
         },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -145,6 +145,7 @@ datastore:
   connMaxIdleTime:
   connMaxLifetime:
   applyMigrations: true
+  waitForMigrations: true
   migrations:
     resources: {}
     image:


### PR DESCRIPTION
This makes the init container that waits for migrations optional via a
`waitForMigrations` flag. If disabled, it does not render the
`initContainer` alongside the role and role binding it uses.

In tools such as ArgoCD, the waves (which can be set throught he helm
annotations we already have) ensure that a resource is applied before
another one. So this waiting init container may not be needed. Let's
make it configurable for deployments that don't require this.

Note that the option defaults to `true` as to keep the current logic and
functionality as it is.
