### PR TITLE
feat: make helm hooks mandatory 

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.34
+version: 0.1.35
 appVersion: "v1.4.2"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -34,17 +34,6 @@ spec:
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
-      initContainers:
-        - name: wait-for-migration
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.datastore.migrations.image.repository }}:{{ .Values.datastore.migrations.image.tag }}"
-          imagePullPolicy: {{ .Values.datastore.migrations.image.pullPolicy }}
-          args: ["job", '{{ include "openfga.fullname" . }}-migrate']
-          resources:
-            {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -8,8 +8,10 @@ metadata:
   {{- with .Values.migrate.labels }}
     {{- toYaml . | nindent 4}}
   {{- end}}
-  {{- with .Values.migrate.annotations }}
   annotations:
+    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+  {{- with .Values.migrate.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -257,8 +257,5 @@ affinity: {}
 sidecars: []
 migrate:
   sidecars: []
-  annotations:
-    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "before-hook-creation"
+  annotations: {}
   labels: {}


### PR DESCRIPTION
## Description
I saw that this PR added the Helm Hooks to the migration job [https://github.com/openfga/helm-charts/pull/70](https://github.com/openfga/helm-charts/pull/70). I think it could be better to make them mandatory instead of default in the values (so it can't be overridden). In addition, i deleted the initContainer that is deprecated when using Helm Hooks.

## References
The PR introducing the migration Helm Hooks [https://github.com/openfga/helm-charts/pull/70](https://github.com/openfga/helm-charts/pull/70)

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
