### PR TITLE
feat(openfga): allow `extraInitContainers` for the openfga deployment

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -34,8 +34,9 @@ spec:
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
+      {{ if or (and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations) .Values.extraInitContainers }}
       initContainers:
+        {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations }}
         - name: wait-for-migration
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -44,6 +45,10 @@ spec:
           args: ["job", '{{ include "openfga.fullname" . }}-migrate']
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -26,6 +26,7 @@ podAnnotations: {}
 extraEnvVars: []
 extraVolumes: []
 extraVolumeMounts: []
+extraInitContainers: []
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
feat(openfga): allow extraInitContainers for the openfga deployment

## Description
This PR adds the ability for an end user to define additional `initContainers` that should run on the openfga deployment.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
