### PR TITLE
feat: add log timestamp format

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.36
+version: 0.1.37
 appVersion: "v1.4.3"
 
 home: "https://openfga.github.io/helm-charts/charts/openfga"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -213,6 +213,11 @@ spec:
               value: {{ .Values.log.level }}
             {{- end }}
 
+            {{- if .Values.log.timestampFormat }}
+            - name: OPENFGA_LOG_TIMESTAMP_FORMAT
+              value: {{ .Values.log.timestampFormat }}
+            {{- end }}
+
             {{- if .Values.maxTuplesPerWrite }}
             - name: OPENFGA_MAX_TUPLES_PER_WRITE
               value: "{{ .Values.maxTuplesPerWrite }}"

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -504,6 +504,15 @@
                         "json"
                     ],
                     "default": "json"
+                },
+                "timestampFormat": {
+                    "type": "string",
+                    "description": "The timestamp format to use for the log output",
+                    "enum": [
+                        "Unix",
+                        "ISO8601"
+                    ],
+                    "default": "Unix"
                 }
             }
         },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -198,6 +198,7 @@ profiler:
 log:
   level: info
   format: json
+  timestampFormat: Unix
 
 checkQueryCache:
   enabled: false


### PR DESCRIPTION
## Description

Allows to pass setting `OPENFGA_LOG_TIMESTAMP_FORMAT` env var via `values.yaml` file. 


## References
Exposes the new functionality added in https://github.com/openfga/openfga/pull/1330

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
