### PR TITLE
feat(openfga): add servicemonitor to OpenFGA chart

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.41
+version: 0.2.0
 appVersion: "v1.5.1"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "openfga.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "openfga.chart" -}}

--- a/charts/openfga/templates/servicemonitor.yaml
+++ b/charts/openfga/templates/servicemonitor.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.telemetry.metrics.enabled .Values.telemetry.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openfga.fullname" . }}
+{{- if .Values.telemetry.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.telemetry.metrics.serviceMonitor.namespace }}
+{{- else }}
+  namespace: {{ include "openfga.namespace" . }}
+{{- end }}
+  labels:
+    {{- include "openfga.labels" . | nindent 4 }}
+  {{- if .Values.telemetry.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.telemetry.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.telemetry.metrics.serviceMonitor.annotations }}
+  annotations: {{ toYaml .Values.telemetry.metrics.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.telemetry.metrics.serviceMonitor.scrapeInterval }}
+      scrapeTimeout: {{ .Values.telemetry.metrics.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.telemetry.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if .Values.telemetry.metrics.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.telemetry.metrics.serviceMonitor.relabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.telemetry.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.telemetry.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+{{- if .Values.telemetry.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.telemetry.metrics.serviceMonitor.jobLabel | quote }}
+{{- end }}
+{{- if .Values.telemetry.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.telemetry.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
+{{- else }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "openfga.namespace" . }}
+{{- end }}
+{{- if .Values.telemetry.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range .Values.telemetry.metrics.serviceMonitor.targetLabels }}
+    - {{ . }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "openfga.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -176,6 +176,66 @@
                             "description": "enable/disable prometheus metrics on the '/metrics' endpoint",
                             "default": true
                         },
+			"serviceMonitor": {
+		            "type": "object",
+			    "properties": {
+			        "enabled": {
+                                    "type": "boolean",
+                                    "description": "enable/disable installation of serviceMonitor custom resource",
+                                    "default": false
+			        },
+			        "additionalLabels": {
+			            "type": "object",
+			            "description": "additional labels to be added to the serivceMonitor resource",
+			            "default": {}
+			        },
+			        "annotations": {
+		                    "type": "object",
+			            "description": "annotations to be added to the serviceMonitor resource",
+			            "default": {}
+			        },
+			        "jobLabel": {
+			            "type": "string",
+			            "description": "the label to use to retrieve the job name from",
+			            "default": "app.kubernetes.io/name"
+			        },
+			        "namespace": {
+		                    "type": "string",
+			            "description": "namespace where the serviceMonitor resource should be installed to",
+			            "default": ""
+			        },
+			        "namespaceSelector": {
+			            "type": "object",
+			            "description": "which namespaces should be scraped",
+			            "default": {}
+			        },
+			        "scrapeInterval": {
+			            "type": "string",
+			            "description": "prometheus scrape interval",
+			            "default": "30s"
+			        },
+			        "scrapeTimeout": {
+			            "type": "string",
+			            "description": "prometheus scrape timeout",
+			            "default": "10s"
+			        },
+			        "targetLabels": {
+			            "type": "array",
+			            "description": "additional target labels to scrape",
+			            "default": []
+			        },
+			        "relabelings": {
+			            "type": "array",
+			            "description": "add job relabelings",
+			            "default": []
+			        },
+			        "metricRelabelings": {
+			            "type": "array",
+			            "description": "add metric relabelings",
+			            "default": []
+			        }
+			    }
+			},
                         "addr": {
                             "type": "string",
                             "description": "the host:port address to serve the prometheus metrics server on",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -123,6 +123,56 @@ telemetry:
     ##
     enabled: true
 
+    serviceMonitor:
+      ## @param telemetry.metrics.serviceMonitor.enabled enable/disable installation of serviceMonitor custom resource
+      ##
+      enabled: false
+
+      ## @param telemetry.metrics.serviceMonitor.additionalLabels additional labels to be added to the serivceMonitor resource
+      ##
+      additionalLabels: {}
+
+      ## @param telemetry.metrics.serviceMonitor.annotations annotations to be added to the serviceMonitor resource
+      ##
+      annotations: {}
+
+      ## @param telemetry.metrics.serviceMonitor.jobLabel the label to use to retrieve the job name from
+      ##
+      jobLabel: "app.kubernetes.io/name"
+
+      ## @param telemetry.metrics.serviceMonitor.namespace namespace where the serviceMonitor resource should be installed to
+      ##
+      namespace: ""
+
+      ## @param telemetry.metrics.serviceMonitor.namespaceSelector which namespaces should be scraped
+      ##
+      ## Default: scrape .Release.Namespace or namespaceOverride only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
+      ##
+      namespaceSelector: {}
+
+      ## @param telemetry.metrics.serviceMonitor.scrapeInterval prometheus scrape interval
+      ##
+      scrapeInterval: 30s
+
+      ## @param telemetry.metrics.serviceMonitor.scrapeTimeout prometheus scrape timeout
+      ##
+      scrapeTimeout: 10s
+
+      ## @param telemetry.metrics.serviceMonitor.targetLabels additional target labels to scrape
+      ##
+      targetLabels: []
+
+      ## @param telemetry.metrics.serviceMonitor.relabelings add job relabelings
+      ##
+      relabelings: []
+
+      ## @param telemetry.metrics.serviceMonitor.metricRelabelings add metric relabelings
+      ##
+      metricRelabelings: []
+
     ## @param telemetry.metrics.addr the host:port address to serve the Metrics server on
     addr: 0.0.0.0:2112
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
This PR adds the possibility to use the ServiceMonitor custom resource from the [prometheus-operator](https://github.com/prometheus-community/prometheus-operator) to scrape the `/metrics` endpoint

## Description
<!-- Provide a detailed description of the changes -->
The changes enable an user of the Chart to deploy a ServiceMonitor custom resource. This is needed if the user wants to use the prometheus-operator to scrape the metrics endpoint

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
