### PR TITLE
chore: pin to the same k8s-wait-for image version

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.1.41
+version: 0.1.42
 appVersion: "v1.5.1"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -41,7 +41,7 @@ securityContext:
 
 initContainer:
   repository: groundnuty/k8s-wait-for
-  tag: "v1.6"
+  tag: "v2.0"
   pullPolicy: IfNotPresent
 
 ## Configure extra options for OpenFGA containers' liveness, readiness and startup probes


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
@lachnerd pointed out that we're using two different versions of `k8s-wait-for` image version, so this makes them the same.

## References
https://github.com/openfga/helm-charts/issues/120

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
