### PR TITLE
chore: upgrading to v1.5.4 for `ListUsers` API support

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,8 +3,8 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.3
-appVersion: "v1.5.3"
+version: 0.2.4
+appVersion: "v1.5.4"
 
 home: "https://openfga.github.io/helm-charts"
 icon: https://github.com/openfga/community/raw/main/brand-assets/icon/color/openfga-icon-color.svg

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -115,6 +115,21 @@ spec:
             - name: OPENFGA_DATASTORE_CONN_MAX_LIFETIME
               value: "{{ .Values.datastore.connMaxLifetime }}"
             {{- end }}
+            
+            {{- if .Values.maxConcurrentReadsForCheck }}
+            - name: OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK
+              value: "{{ .Values.maxConcurrentReadsForCheck }}"
+            {{- end }}
+
+            {{- if .Values.maxConcurrentReadsForListObjects }}
+            - name: OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS
+              value: "{{ .Values.maxConcurrentReadsForListObjects }}"
+            {{- end }}
+
+            {{- if .Values.maxConcurrentReadsForListUsers }}
+            - name: OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_USERS
+              value: "{{ .Values.maxConcurrentReadsForListUsers }}"
+            {{- end }}
 
             {{- if .Values.experimentals }}
             - name: OPENFGA_EXPERIMENTALS

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -258,6 +258,16 @@ spec:
               value: "{{ .Values.listObjectsMaxResults }}"
             {{- end }}
 
+            {{- if .Values.listUsersDeadline }}
+            - name: OPENFGA_LIST_USERS_DEADLINE
+              value: "{{ .Values.listUsersDeadline }}"
+            {{- end }}
+
+            {{- if .Values.listUsersMaxResults }}
+            - name: OPENFGA_LIST_USERS_MAX_RESULTS
+              value: "{{ .Values.listUsersMaxResults }}"
+            {{- end }}
+
             {{- if .Values.checkQueryCache.enabled }}
             - name: OPENFGA_CHECK_QUERY_CACHE_ENABLED
               value: "{{ .Values.checkQueryCache.enabled }}"

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -609,7 +609,12 @@
         "experimentals": {
             "type": "array",
             "description": "a list of experimental features to enable",
-            "default": []
+            "default": [],
+            "examples": ["enable-list-users"],
+            "items": {
+                "type": "string",
+                "enum": ["enable-list-users"]
+            }
         },
         "maxTuplesPerWrite": {
             "type": [
@@ -646,6 +651,14 @@
                 "null"
             ],
             "description": "the maximum allowed number of concurrent reads in a single ListObjects query",
+            "default": 4294967295
+        },
+        "maxConcurrentReadsForListUsers": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "the maximum allowed number of concurrent reads in a single ListUsers query",
             "default": 4294967295
         },
         "changelogHorizonOffset": {
@@ -689,6 +702,26 @@
                 "null"
             ],
             "description": "the maximum results to return in ListObjects responses"
+        },
+        "listUsersDeadline": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "the timeout deadline (as a duration) for serving ListUsers requests",
+            "format": "duration",
+            "examples": [
+                "3s",
+                "1m",
+                "200ms"
+            ]
+        },
+        "listUsersMaxResults": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "the maximum results to return in ListUsers responses"
         },
         "requestDurationDatastoreQueryCountBuckets": {
             "description": "datastore query count buckets used to label the histogram metric for measuring request duration.",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -262,11 +262,14 @@ maxTypesPerAuthorizationModel:
 maxAuthorizationModelSizeInBytes:
 maxConcurrentReadsForCheck:
 maxConcurrentReadsForListObjects:
+maxConcurrentReadsForListUsers:
 changelogHorizonOffset:
 resolveNodeLimit:
 resolveNodeBreadthLimit:
 listObjectsDeadline:
 listObjectsMaxResults:
+listUsersDeadline:
+listUsersMaxResults:
 requestDurationDatastoreQueryCountBuckets: [50, 200]
 allowWriting1_0Models:
 allowEvaluating1_0Models:


### PR DESCRIPTION
## Description
Upgrades to OpenFGA v1.5.4 which includes experimental support for the ListUsers API. Along with the version bump is support for this new API's configurations as well as adding in some missing configurations.

~**Note:** This PR is in draft until 1.5.4 is released; there is [1.5.4-rc1](https://github.com/openfga/openfga/releases/tag/v1.5.4-rc1) out though.~

## References
- [ListUsers OpenFGA PR](https://github.com/openfga/openfga/pull/1433)
- [1.5.4-rc1 release](https://github.com/openfga/openfga/releases/tag/v1.5.4-rc1)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
