### PR TITLE
feat: include "extraEnvVars" as part of the migration job

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.6
+version: 0.2.5
 appVersion: "v1.5.4"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "v1.5.3"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "v1.5.4"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -51,6 +51,11 @@ spec:
                   name: "{{ .Values.datastore.uriSecret }}"
                   key: "uri"
             {{- end }}
+
+            {{- with .Values.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
         {{- if .Values.migrate.sidecars }}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

From reading the code I see no way of providing the same `extraEnvVars` as done to the deployment for the migration job. The only way I can see is to directly add `datastore.uri` as part of the values file which is not something we want since it is a secret and something we want to commit to a git repository. It is from what I've found (please correct me if so) not possible to to use something like ExternalSecret to load the value dynamically rather than hardcoding it in the values file.

I'd like to be able to do something like

We are currently running this version of the chart in production and it works just fine.

```
openfga:
  extraEnvVars:
    - name: OPENFGA_DATASTORE_URI
      valueFrom:
        secretKeyRef:
          name: openfga-external-secrets
          key: OPENFGA_DATASTORE_URI
```
but it is currently not picked up by the migration job.

## References

How it is done in the deployment file: 

https://github.com/openfga/helm-charts/blob/40ea4e1936efb04da540d1d2afe7e6375eedda3f/charts/openfga/templates/deployment.yaml#L326

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
