### PR TITLE
feat: more control on the migration job hook

### DIFF
--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -18,6 +18,11 @@ spec:
       {{- with .Values.migrate.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
+        {{- if .Values.migrate.hook.enable }}
+          helm.sh/hook: {{ .Values.migrate.hook.hook }}
+          helm.sh/hook-weight: {{ .Values.migrate.hook.hookWeight }}
+          helm.sh/hook-delete-policy: {{ .Values.migrate.hook.hookDeletePolicy }}
+        {{- end}}
       {{- end }}
       {{- with .Values.migrate.labels }}
       labels:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -925,6 +925,31 @@
                     "description": "add additional sidecar containers to the migration job",
                     "default": []
                 },
+                "hook": {
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "type": "boolean",
+                            "description": "Enable/disable the hook for the migration job",
+                            "default": true
+                        },
+                        "hook": {
+                            "type": "string",
+                            "description": "Names of hook for the migration job, separated by a comma",
+                            "default": "post-install, post-upgrade, post-rollback, post-delete"
+                        },
+                        "hookWeight": {
+                            "type": "string",
+                            "description": "Weight of Helm hook",
+                            "default": "-5"
+                        },
+                        "hookDeletePolicy": {
+                            "type": "string",
+                            "description": "Delete policy of the Helm hook for the migration job",
+                            "default": "before-hook-creation"
+                        }
+                    }
+                },
                 "annotations": {
                     "type": "object",
                     "description": "Map of annotations to add to the migration job's manifest",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -320,9 +320,11 @@ affinity: {}
 sidecars: []
 migrate:
   sidecars: []
-  annotations:
-    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "before-hook-creation"
+  hook:
+    enable: true
+    hook: "post-install, post-upgrade, post-rollback, post-delete"
+    hookWeight: "-5"
+    hookDeletePolicy: "before-hook-creation"
+  annotations: {}
   labels: {}
   timeout:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

I made the migration job hook configurable, so that it can be completely deleted.

## Description
<!-- Provide a detailed description of the changes -->

The rationale is that if someone deploys the chart with the --wait flag of helm, the deployment will wait forever (see #120).
We must remove the hook to solve this. The PR provides a way to do this without breaking changes.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
