### PR TITLE
feat: expose username and password environment variables

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -96,6 +96,28 @@ spec:
                   key: "uri"
             {{- end }}
 
+            {{- if .Values.datastore.username }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              value: "{{ .Values.datastore.username }}"
+            {{- else if .Values.datastore.credentialsSecret }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.credentialsSecret }}"
+                  key: "{{ .Values.datastore.credentialsSecretUsernameKey }}"
+            {{- end }}
+
+            {{- if .Values.datastore.password }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              value: "{{ .Values.datastore.password }}"
+            {{- else if .Values.datastore.credentialsSecret }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.credentialsSecret }}"
+                  key: "{{ .Values.datastore.credentialsSecretPasswordKey }}"
+            {{- end }}
+
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE
               value: "{{ .Values.datastore.maxCacheSize }}"

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -52,6 +52,28 @@ spec:
                   key: "uri"
             {{- end }}
 
+            {{- if .Values.datastore.username }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              value: "{{ .Values.datastore.username }}"
+            {{- else if .Values.datastore.credentialsSecret }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.credentialsSecret }}"
+                  key: "{{ .Values.datastore.credentialsSecretUsernameKey }}"
+            {{- end }}
+
+            {{- if .Values.datastore.password }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              value: "{{ .Values.datastore.password }}"
+            {{- else if .Values.datastore.credentialsSecret }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.credentialsSecret }}"
+                  key: "{{ .Values.datastore.credentialsSecretPasswordKey }}"
+            {{- end }}
+
             {{- if .Values.migrate.timeout }}
             - name: OPENFGA_TIMEOUT
               value: "{{ .Values.migrate.timeout }}"

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -189,7 +189,7 @@
 			        },
 			        "additionalLabels": {
 			            "type": "object",
-			            "description": "additional labels to be added to the serivceMonitor resource",
+			            "description": "additional labels to be added to the serviceMonitor resource",
 			            "default": {}
 			        },
 			        "annotations": {
@@ -279,6 +279,41 @@
                         "null"
                     ],
                     "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
+                },
+                "username": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the connection username to connect to the datastore (overwrites any username provided in the connection uri)"
+                },
+                "password": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the connection password to connect to the datastore (overwrites any password provided in the connection uri)"
+                },
+                "credentialsSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the secret name where to get the username and password for the datastore database"
+                },
+                "credentialsSecretUsernameKey": {
+                    "type": [
+                        "string"
+                    ],
+                    "description": "the key for the username in the credentialsSecret",
+                    "default": "username"
+                },
+                "credentialsSecretPasswordKey": {
+                    "type": [
+                        "string"
+                    ],
+                    "description": "the key for the password in the credentialsSecret",
+                    "default": "password"
                 },
                 "maxCacheSize": {
                     "type": [

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -129,7 +129,7 @@ telemetry:
       ##
       enabled: false
 
-      ## @param telemetry.metrics.serviceMonitor.additionalLabels additional labels to be added to the serivceMonitor resource
+      ## @param telemetry.metrics.serviceMonitor.additionalLabels additional labels to be added to the serviceMonitor resource
       ##
       additionalLabels: {}
 
@@ -190,6 +190,11 @@ datastore:
   engine: memory
   uri:
   uriSecret:
+  username:
+  password:
+  credentialsSecret:
+  credentialsSecretUsernameKey: username
+  credentialsSecretPasswordKey: password
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR exposes the OPENFGA_DATASTORE_USERNAME and OPENFGA_DATASTORE_PASSWORD environment variables. They can be references directly in the values file, or through a secret. The username and password keys in the secret are also configurable. I took inspiration from [Keycloak's way](https://github.com/bitnami/charts/blob/d9f1b3799e265fdb63f823e496045abb1557c05a/bitnami/keycloak/values.yaml#L1304) of accessing username and password from an existing secret.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
