### PR TITLE
Add extra volumes to migrate job

### DIFF
--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -63,10 +63,20 @@ spec:
 
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
         {{- if .Values.migrate.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
         {{- end }}
       restartPolicy: Never
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
This PR adds the `extraVolumes` and `extraVolumeMounts` to the migration job.

## Description
<!-- Provide a detailed description of the changes -->
I have a use case where I want to mount a CA cert bundle into the openfga deployment which is used 
for the database connection.
It works fine for service, but the migration has no way that I can see to get the cert currently.
I think it is probably okay to re-use the existing vars for the volumes in the migrate job,
but I'm happy to move those to a separate value if that is preferable.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
