### PR TITLE
feat: add extraMounts and volumes to migrate job

### DIFF
--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -63,10 +63,18 @@ spec:
 
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+          {{- with .Values.migrate.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.migrate.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
         {{- end }}
       restartPolicy: Never
+      {{- with .Values.migrate.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -925,6 +925,16 @@
                     "description": "add additional sidecar containers to the migration job",
                     "default": []
                 },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "add additional volumes to the migration job",
+                    "default": []
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "add additional volumeMounts to the migration job",
+                    "default": []
+                },
                 "annotations": {
                     "type": "object",
                     "description": "Map of annotations to add to the migration job's manifest",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -319,6 +319,8 @@ affinity: {}
 #         containerPort: 1234
 sidecars: []
 migrate:
+  extraVolumes: []
+  extraVolumeMounts: []
   sidecars: []
   annotations:
     helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

This PR adds the extraVolumes and extraVolumeMounts to the migration job.

## Description
As this PR (https://github.com/openfga/helm-charts/pull/142) also already did, I added extraVolumes and extraVolumeMounts to the migrate job allowing for different scenarios not possible without, eg. mounting CA bundles or mounting secrets via SPC for the database credentials to be used by the job.

Compared to the other PR I also added the default values in the values.yaml and added the new values to the validation schema.

## References
https://github.com/openfga/helm-charts/pull/142


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
