### PR TITLE
fix: add quotes around oidc options

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -205,12 +205,12 @@ spec:
 
             {{- if .Values.authn.oidc.audience }}
             - name: OPENFGA_AUTHN_OIDC_AUDIENCE
-              value: {{ .Values.authn.oidc.audience }}
+              value: "{{ .Values.authn.oidc.audience }}"
             {{- end }}
 
             {{- if .Values.authn.oidc.issuer }}
             - name: OPENFGA_AUTHN_OIDC_ISSUER
-              value: {{ .Values.authn.oidc.issuer }}
+              value: "{{ .Values.authn.oidc.issuer }}"
             {{- end }}
 
             - name: OPENFGA_PLAYGROUND_ENABLED


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Added quotes to ensure the environment variable value is always treated as a string. Zitadel and Azure seemingly offer audiences that are longInts.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://github.com/openfga/helm-charts/issues/152

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
