### PR TITLE
fix: timeout on chart uninstall

### DIFF
--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -323,7 +323,7 @@ migrate:
   extraVolumeMounts: []
   sidecars: []
   annotations:
-    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
+    helm.sh/hook: "post-install, post-upgrade, post-rollback"
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: "before-hook-creation"
   labels: {}


### PR DESCRIPTION
fix timeout on chart uninstall

## Description
Chart uninstallation takes 5 minutes before it times out, as it waits for the migration job to finish. However, the job cannot run because the service account has already been deleted.
Fix removes the post-delete hook on migrate job.

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
