### PR TITLE
feat: optionally run migrations as an init contianer

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{ if or (and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations .Values.datastore.waitForMigrations) .Values.extraInitContainers }}
       initContainers:
-        {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations .Values.datastore.waitForMigrations }}
+        {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations .Values.datastore.waitForMigrations (eq .Values.datastore.migrationType "job") }}
         - name: wait-for-migration
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -45,6 +45,44 @@ spec:
           args: ["job-wr", '{{ include "openfga.fullname" . }}-migrate']
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+        {{- end }}
+        {{- if and (has .Values.datastore.engine (list "postgres" "mysql")) (eq .Values.datastore.migrationType "initContainer") }}
+        - name: migrate-database
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args: [ "migrate" ]
+          env:
+            {{- if .Values.datastore.engine }}
+            - name: OPENFGA_DATASTORE_ENGINE
+              value: "{{ .Values.datastore.engine }}"
+            {{- end }}
+            {{- if .Values.datastore.uri }}
+            - name: OPENFGA_DATASTORE_URI
+              value: "{{ .Values.datastore.uri }}"
+            {{- else if .Values.datastore.uriSecret }}
+            - name: OPENFGA_DATASTORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.uriSecret }}"
+                  key: "uri"
+            {{- end }}
+            {{- if .Values.migrate.timeout }}
+            - name: OPENFGA_TIMEOUT
+              value: "{{ .Values.migrate.timeout }}"
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
+          {{- with .Values.migrate.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.migrate.sidecars }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations -}}
+{{- if and (has .Values.datastore.engine (list "postgres" "mysql")) .Values.datastore.applyMigrations (eq .Values.datastore.migrationType "job") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -329,8 +329,20 @@
                 },
                 "applyMigrations": {
                     "type": "boolean",
-                    "description": "enable/disable the job that runs migrations in the datastore",
+                    "description": "enable/disable the running of migrations in the datastore",
                     "default": true
+                },
+                "migrationType": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "how the migrations will be run",
+                    "default": "job",
+                    "enum": [
+                        "job",
+                        "initContainer"
+                    ]
                 },
                 "waitForMigrations": {
                     "type": "boolean",


### PR DESCRIPTION
As covered in a few other issues and PRs, there's a deadlock situation with the chart when deploying with `helm --wait` and/or ArgoCD:

1. The OpenFGA Pod won't start until the migrations have been applied
2. The Migration Job applies the migrations, and is configured as a Helm Hook
3. When using `helm --wait` (or ArgoCD) hooks aren't run until all Pods are healthy
4. Deadlock: Job won't start because the Pod isn't healthy yet, Pod will never become healthy until the Job runs

## Description

This PR introduces an alternative mechanism for running the migrations: an init container on the OpenFGA pod. Instead of waiting for a Job to run, the migrations are ran when the Pod first starts as an init container.

A new `migrationType` value is added, which can be set to `job` or `initContainer` and defaults to `job` (so is a backwards-compatible change). If set to `job` the chart behaves as it currently does, but if set to `initContainer` then the following happens:

1. the Job is not created
2. the `wait-for-container` init container is not included on the Deployment
3. a new `migrate-database` init container is included instead

## References
- https://github.com/openfga/helm-charts/issues/100
- https://github.com/openfga/helm-charts/issues/120
- https://github.com/openfga/helm-charts/issues/131
- https://github.com/openfga/helm-charts/pull/99
- https://github.com/openfga/helm-charts/pull/138

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
