### PR TITLE
feat: template datastore uri secret

### DIFF
--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,3 +77,19 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate an environment variable for the datastore URI
+*/}}
+{{- define "openfga.datastoreURIEnvVar" -}}
+{{- if .Values.datastore.uri -}}
+- name: OPENFGA_DATASTORE_URI
+  value: "{{ .Values.datastore.uri }}"
+{{- else if .Values.datastore.uriSecret -}}
+- name: OPENFGA_DATASTORE_URI
+  valueFrom:
+    secretKeyRef:
+      name: "{{ tpl .Values.datastore.uriSecret . }}"
+      key: "{{ tpl (.Values.datastore.uriSecretKey | default "uri") . }}"
+{{- end -}}
+{{- end -}}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -85,16 +85,7 @@ spec:
               value: "{{ .Values.datastore.engine }}"
             {{- end }}
 
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
+            {{- include "openfga.datastoreURIEnvVar" . | nindent 12 }}
 
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -41,16 +41,7 @@ spec:
               value: "{{ .Values.datastore.engine }}"
             {{- end }}
 
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
+            {{- include "openfga.datastoreURIEnvVar" . | nindent 12 }}
 
             {{- if .Values.migrate.timeout }}
             - name: OPENFGA_TIMEOUT

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -278,7 +278,15 @@
                         "string",
                         "null"
                     ],
-                    "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
+                    "description": "the secret name where to get the datastore URI, it expects the key in `uriSecretKey` to exist in the secret"
+                },
+                "uriSecretKey": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": "uri",
+                    "description": "the key in the secret where to get the datastore URI, defaults to uri"
                 },
                 "maxCacheSize": {
                     "type": [

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -190,6 +190,7 @@ datastore:
   engine: memory
   uri:
   uriSecret:
+  uriSecretKey:
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:


### PR DESCRIPTION
It's useful to be able to template the secret ref for the datastore uri.

Situation where it's helpful:

1. You want to use a secret for the URI, not setting the uri/value directly
2. You may not know the secret name ahead of time, it's being set externally as a value
3. You're packaging openfga as part of an umbrella chart, and want to abstract configuration of openfga/you don't want users of your umbrella chart to have to know the structure of the openfga chart to be able to change database settings.

## Description

Add a call to `tpl` before setting the environment variable, which allows variable substitution.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
