### PR TITLE
BREAKING: Consolidate configuration for migrations in values.yaml

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -148,7 +148,7 @@ spec:
 
             {{- if .Values.grpc.tls.enabled }}
             - name: OPENFGA_GRPC_TLS_ENABLED
-              value: {{ .Values.grpc.tls.enabled }}
+              value: "{{ .Values.grpc.tls.enabled }}"
 
             - name: OPENFGA_GRPC_TLS_CERT
               value: {{ .Values.grpc.tls.cert }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -161,7 +161,7 @@ spec:
             - name: OPENFGA_DATASTORE_CONN_MAX_LIFETIME
               value: "{{ .Values.datastore.connMaxLifetime }}"
             {{- end }}
-            
+
             {{- if .Values.maxConcurrentReadsForCheck }}
             - name: OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK
               value: "{{ .Values.maxConcurrentReadsForCheck }}"
@@ -189,7 +189,7 @@ spec:
 
             {{- if .Values.grpc.tls.enabled }}
             - name: OPENFGA_GRPC_TLS_ENABLED
-              value: "{{ .Values.grpc.tls.enabled }}"
+              value: {{ .Values.grpc.tls.enabled }}
 
             - name: OPENFGA_GRPC_TLS_CERT
               value: {{ .Values.grpc.tls.cert }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -5,21 +5,21 @@ metadata:
   name: {{ include "openfga.fullname" . }}-migrate
   labels:
     {{- include "openfga.labels" . | nindent 4 }}
-  {{- with .Values.migrate.labels }}
+  {{- with .Values.datastore.migrations.labels }}
     {{- toYaml . | nindent 4}}
   {{- end}}
-  {{- with .Values.migrate.annotations }}
+  {{- with .Values.datastore.migrations.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   template:
     metadata:
-      {{- with .Values.migrate.annotations }}
+      {{- with .Values.datastore.migrations.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.migrate.labels }}
+      {{- with .Values.datastore.migrations.labels }}
       labels:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -52,9 +52,9 @@ spec:
                   key: "uri"
             {{- end }}
 
-            {{- if .Values.migrate.timeout }}
+            {{- if .Values.datastore.migrations.timeout }}
             - name: OPENFGA_TIMEOUT
-              value: "{{ .Values.migrate.timeout }}"
+              value: "{{ .Values.datastore.migrations.timeout }}"
             {{- end }}
 
             {{- with .Values.extraEnvVars }}
@@ -63,15 +63,15 @@ spec:
 
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
-          {{- with .Values.migrate.extraVolumeMounts }}
+          {{- with .Values.datastore.migrations.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if .Values.migrate.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
+        {{- if .Values.datastore.migrations.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.datastore.migrations.sidecars "context" $) | nindent 8 }}
         {{- end }}
       restartPolicy: Never
-      {{- with .Values.migrate.extraVolumes }}
+      {{- with .Values.datastore.migrations.extraVolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -203,6 +203,16 @@ datastore:
       repository: groundnuty/k8s-wait-for
       pullPolicy: Always
       tag: "v2.0"
+    extraVolumes: []
+    extraVolumeMounts: []
+    sidecars: []
+    annotations:
+      helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: "before-hook-creation"
+    labels: {}
+    timeout:
+
 
 postgresql:
   ## @param postgresql.enabled enable the bitnami/postgresql subchart and deploy Postgres
@@ -318,16 +328,6 @@ affinity: {}
 #       - name: portname
 #         containerPort: 1234
 sidecars: []
-migrate:
-  extraVolumes: []
-  extraVolumeMounts: []
-  sidecars: []
-  annotations:
-    helm.sh/hook: "post-install, post-upgrade, post-rollback, post-delete"
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: "before-hook-creation"
-  labels: {}
-  timeout:
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
Consolidate configuration for migrations in values.yaml

## Description
<!-- Provide a detailed description of the changes -->
Currently the migrations job is being configured in 2 places: `.datastore.migrations` and `.migrate`. I have removed `.migrate` and shifted all keys to `.datastore.migrations`.

Also sneaked in a possible fix for #2 for `.grpc.tls.enabled`

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
#2

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
