### PR TITLE
feat: configure datastore username and password separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,21 +19,12 @@ jobs:
       - name: Configure Git
         run: |
           git config user.name github-actions
-          git config user.email contact@openfga.dev
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-
-      - name: Export GPG key to legacy format
-        run: gpg --export-secret-keys > ~/.gnupg/pubring.gpg
+          git config user.email jasper.vaneessen@ugent.be
 
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.5.0
+          version: v3.16.2
 
       - name: Add Helm Repositories
         run: |
@@ -43,8 +34,6 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
-        with:
-          config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,3 +77,41 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "openfga.datastore.envConfig" -}}
+{{- if .Values.datastore.engine }}
+- name: OPENFGA_DATASTORE_ENGINE
+  value: "{{ .Values.datastore.engine }}"
+{{- end }}
+{{- if .Values.datastore.uri }}
+- name: OPENFGA_DATASTORE_URI
+  value: "{{ .Values.datastore.uri}}"
+{{- else if .Values.datastore.uriSecret }}
+- name: OPENFGA_DATASTORE_URI
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.uriSecret }}"
+      key: "uri"
+{{- end }}
+{{- if .Values.datastore.password }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  value: "{{ .Values.datastore.password }}"
+{{- else if .Values.datastore.passwordSecret }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.passwordSecret }}"
+      key: "password"
+{{- end -}}
+{{- if .Values.datastore.username }}
+- name: OPENFGA_DATASTORE_USER
+  value: "{{ .Values.datastore.username }}"
+{{- else if .Values.datastore.usernameSecret }}
+- name: OPENFGA_DATASTORE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.usernameSecret }}"
+      key: "username"
+{{- end }}
+{{- end -}}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,15 +77,3 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "openfga.datastore.uri" -}}
-{{- if not .Values.datastore.uri -}}
-    {{- if eq datastore.engine "postgresql" }}
-        {{- printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
-    {{- else if eq datastore.engine "mysql" }}
-        {{- printf "%s:%s@tcp(%s:%s)/%s?parseTime=true" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
-    {{- end -}}
-{{- else -}}
-    {{- .Values.datastore.uri | quote -}}
-{{- end }}
-{{- end }}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,3 +77,15 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "openfga.datastore.uri" -}}
+{{- if not .Values.datastore.uri -}}
+    {{- if eq datastore.engine "postgresql" }}
+        {{- printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
+    {{- else if eq datastore.engine "mysql" }}
+        {{- printf "%s:%s@tcp(%s:%s)/%s?parseTime=true" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
+    {{- end -}}
+{{- else -}}
+    {{- .Values.datastore.uri | quote -}}
+{{- end }}
+{{- end }}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -84,34 +84,34 @@ Return true if a secret object should be created
 - name: OPENFGA_DATASTORE_ENGINE
   value: "{{ .Values.datastore.engine }}"
 {{- end }}
-{{- if .Values.datastore.uri }}
-- name: OPENFGA_DATASTORE_URI
-  value: "{{ .Values.datastore.uri}}"
-{{- else if .Values.datastore.uriSecret }}
+{{- if .Values.datastore.externalSecret.uriSecretKey }}
 - name: OPENFGA_DATASTORE_URI
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.uriSecret }}"
-      key: "uri"
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.uriSecretKey }}"
+{{- else if .Values.datastore.uri }}
+- name: OPENFGA_DATASTORE_URI
+  value: "{{ .Values.datastore.uri }}"
 {{- end }}
-{{- if .Values.datastore.password }}
-- name: OPENFGA_DATASTORE_PASSWORD
-  value: "{{ .Values.datastore.password }}"
-{{- else if .Values.datastore.passwordSecret }}
-- name: OPENFGA_DATASTORE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: "{{ .Values.datastore.passwordSecret }}"
-      key: "password"
-{{- end -}}
-{{- if .Values.datastore.username }}
-- name: OPENFGA_DATASTORE_USER
-  value: "{{ .Values.datastore.username }}"
-{{- else if .Values.datastore.usernameSecret }}
+{{- if .Values.datastore.externalSecret.usernameSecretKey }}
 - name: OPENFGA_DATASTORE_USERNAME
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.usernameSecret }}"
-      key: "username"
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.usernameSecretKey }}"
+{{- else if .Values.datastore.username }}
+- name: OPENFGA_DATASTORE_USERNAME
+  value: "{{ .Values.datastore.username }}"
+{{- end }}
+{{- if .Values.datastore.externalSecret.passwordSecretKey }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.passwordSecretKey }}"
+{{- else if .Values.datastore.password }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  value: "{{ .Values.datastore.password }}"
 {{- end }}
 {{- end -}}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not  .Values.autoscaling.enabled }}
   replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory")}}
   {{- end }}
   selector:
@@ -80,43 +80,7 @@ spec:
             {{- end }}
 
           env:
-            {{- if .Values.datastore.engine }}
-            - name: OPENFGA_DATASTORE_ENGINE
-              value: "{{ .Values.datastore.engine }}"
-            {{- end }}
-
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: {{ include "openfga.datastore.uri" . }}
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
-
-            {{- if .Values.datastore.password}}
-            - name: OPENFGA_DATASTORE_PASSWORD
-              value: "{{ .Values.datastore.password }}"
-            {{- else if .Values.datastore.passwordSecret }}
-            - name: OPENFGA_DATASTORE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.passwordSecret }}"
-                  key: "password"
-            {{- end }}
-
-            {{- if .Values.datastore.username }}
-            - name: OPENFGA_DATASTORE_USER
-              value: "{{ .Values.datastore.username }}"
-            {{- else if .Values.datastore.usernameSecret }}
-            - name: OPENFGA_DATASTORE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.userSecret }}"
-                  key: "username"
-            {{- end }}
+            {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -96,6 +96,28 @@ spec:
                   key: "uri"
             {{- end }}
 
+            {{- if .Values.datastore.password}}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              value: "{{ .Values.datastore.password }}"
+            {{- else if .Values.datastore.passwordSecret }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.passwordSecret }}"
+                  key: "password"
+            {{- end }}
+
+            {{- if .Values.datastore.username }}
+            - name: OPENFGA_DATASTORE_USER
+              value: "{{ .Values.datastore.username }}"
+            {{- else if .Values.datastore.usernameSecret }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.userSecret }}"
+                  key: "username"
+            {{- end }}
+
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE
               value: "{{ .Values.datastore.maxCacheSize }}"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
 
             {{- if .Values.datastore.uri }}
             - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
+              value: {{ include "openfga.datastore.uri" . }}
             {{- else if .Values.datastore.uriSecret }}
             - name: OPENFGA_DATASTORE_URI
               valueFrom:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -36,21 +36,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args: ["migrate"]
           env:
-            {{- if .Values.datastore.engine }}
-            - name: OPENFGA_DATASTORE_ENGINE
-              value: "{{ .Values.datastore.engine }}"
-            {{- end }}
-
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
+            {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 
             {{- if .Values.migrate.timeout }}
             - name: OPENFGA_TIMEOUT

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -274,21 +274,7 @@
                     ],
                     "description": "the URI of the datastore including credentials and database (e.g. postgres://user:password@host:port/dbname)"
                 },
-                "host": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "the host address of the datastore"
-                },
-                "port": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "the port of the datastore"
-                },
-                "user": {
+                "username": {
                     "type": [
                         "string",
                         "null"
@@ -308,6 +294,20 @@
                         "null"
                     ],
                     "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
+                },
+                "usernameSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the secret name where to get the datastore username, it expects a key named username to exist in the secret"
+                },
+                "passwordSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the secret name where to get the datastore password, it expects a key named password to exist in the secret"
                 },
                 "maxCacheSize": {
                     "type": [

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -271,7 +271,36 @@
                     "type": [
                         "string",
                         "null"
-                    ]
+                    ],
+                    "description": "the URI of the datastore including credentials and database (e.g. postgres://user:password@host:port/dbname)"
+                },
+                "host": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the host address of the datastore"
+                },
+                "port": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "the port of the datastore"
+                },
+                "user": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the username to authenticate with the datastore"
+                },
+                "password": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the password to authenticate with the datastore"
                 },
                 "uriSecret": {
                     "type": [

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -189,6 +189,10 @@ telemetry:
 datastore:
   engine: memory
   uri:
+  host:
+  port:
+  user:
+  password:
   uriSecret:
   maxCacheSize:
   maxOpenConns:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -189,11 +189,11 @@ telemetry:
 datastore:
   engine: memory
   uri:
-  host:
-  port:
-  user:
+  username:
   password:
   uriSecret:
+  usernameSecret:
+  passwordSecret:
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -191,9 +191,11 @@ datastore:
   uri:
   username:
   password:
-  uriSecret:
-  usernameSecret:
-  passwordSecret:
+  externalSecret:
+    name: ""
+    uriSecretKey: ""
+    usernameSecretKey: ""
+    passwordSecretKey: ""
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

The chart currently only support setting the datastore URI through values or secret. We deploy postgres using an operator that creates secrets with credentials and want to be able to feed username and password through the secret.

Goals of this PR:

- Add config option for username and password
- Allow config to be fed by a secret
- Move common datastore config to helper function so they can be included (`deployment` and `job` both use them)

Working example in our case, using zalando operator to create postgres cluster, the zalando operator creates a secret in the openfga namespace with credentials:

```yaml
datastore:
  engine: postgres
  uri: postgres://openfga:password@pgobelisk.postgresql:5432/openfga
  passwordSecret: openfga.openfga.pgobelisk.credentials.postgresql.acid.zalan.do
  usernameSecret: openfga.openfga.pgobelisk.credentials.postgresql.acid.zalan.do
```

In this PR I have mimicked how the uriSecret functions in that it uses a hard coded reference key (`uri`, `username` and `password`). This is already being used to deploy openfga on our development server.

But I would actually propose to change how uriSecret works similar to bitnami charts, with a configurable secret key:

```yaml
datastore:
  engine: postgres
  uri: postgres://user:password@pgopenfga.postgresql:5432/openfga
  externalSecret:
    name: openfga.openfga.pgobelisk.credentials.postgresql.acid.zalan.do
    uriSecretKey: ""
    passwordSecretKey: "password"
    usernameSecretKey: "username"
```

This would be setup like so:
1. if secretKey for config value is set (default they are null or empty string), then we use the secret
2. secretKey not set, then we use the default

This way you can mix and match values from config and from secrets by setting the reference keys.


## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
