### PR TITLE
feat: expand datastore connection configuration (username, password and uri) and allow set-up through an existing secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,21 +19,12 @@ jobs:
       - name: Configure Git
         run: |
           git config user.name github-actions
-          git config user.email contact@openfga.dev
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-
-      - name: Export GPG key to legacy format
-        run: gpg --export-secret-keys > ~/.gnupg/pubring.gpg
+          git config user.email jasper.vaneessen@ugent.be
 
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.5.0
+          version: v3.16.2
 
       - name: Add Helm Repositories
         run: |
@@ -43,8 +34,6 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
-        with:
-          config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Add Helm Repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami https://repo.broadcom.com/bitnami-files
           helm repo add openfga https://openfga.github.io/helm-charts
           helm repo update
 

--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.12.10
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.13.3
-digest: sha256:a152c0abc09cadc6a2158e237b67485b3177d1ed8ad9b7f0b64af300b4eb6e25
-generated: "2024-03-07T16:13:52.695937-07:00"
+digest: sha256:0a0986b7eaf3e674035b7d87cd52babd574bf05b867a00dcdfad450c88607ec8
+generated: "2024-12-16T11:22:51.356552959+01:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -18,11 +18,11 @@ annotations:
 dependencies:
   - name: postgresql
     version: "12.12.10"
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mysql
     version: "9.6.0"
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: mysql.enabled
   - name: common
     version: "2.13.3"

--- a/charts/openfga/README.md
+++ b/charts/openfga/README.md
@@ -66,6 +66,50 @@ $ helm install openfga openfga/openfga \
 
 This will bootstrap a MySQL deployment using the [`bitnami/mysql`](https://artifacthub.io/packages/helm/bitnami/mysql) chart and deploy OpenFGA configured in a way to connect to it.
 
+### Connecting to an existing Postgres or MySQL deployment
+
+If you have an existing Postgres or MySQL deployment, you can connect OpenFGA to it by providing the `datastore.uri` parameter. For example, to connect to a Postgres deployment:
+
+```
+$ helm install openfga openfga/openfga \
+  --set datastore.engine=postgres \
+  --set datastore.uri="postgres://postgres:password@postgres.postgres:5432/postgres?sslmode=disable"
+```
+
+### Using an existing secret for Postgres or MySQL
+
+If you have an existing secret with the connection details for Postgres or MySQL, you can reference the secret in the values file. For example, say you have created the following secret for Postgres:
+
+```sh
+kubectl create secret generic my-postgres-secret \
+  --from-literal=uri="postgres://postgres.postgres:5432/postgres?sslmode=disable" \
+  --from-literal=username=postgres --from-literal=password=password
+```
+
+You can reference this secret in the values file as follows:
+
+```yaml
+datastore:
+  engine: postgres
+  existingSecret: my-postgres-secret
+  secretKeys:
+    uri: uri
+    username: username
+    password: password
+```
+
+You can also mix and match both static config and secret references. When the secret key is defined, the static config will be ignored. The following example shows how to reference the secret for username and password, but provide the URI statically:
+
+```yaml
+datastore:
+  engine: postgres
+  uri: "postgres://postgres.postgres:5432/postgres?sslmode=disable"
+  existingSecret: my-postgres-secret
+  secretKeys:
+    username: username
+    password: password
+```
+
 ## Uninstalling the Chart
 To uninstall/delete the `openfga` deployment:
 

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,3 +77,41 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "openfga.datastore.envConfig" -}}
+{{- if .Values.datastore.engine }}
+- name: OPENFGA_DATASTORE_ENGINE
+  value: "{{ .Values.datastore.engine }}"
+{{- end }}
+{{- if .Values.datastore.uri }}
+- name: OPENFGA_DATASTORE_URI
+  value: "{{ .Values.datastore.uri}}"
+{{- else if .Values.datastore.uriSecret }}
+- name: OPENFGA_DATASTORE_URI
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.uriSecret }}"
+      key: "uri"
+{{- end }}
+{{- if .Values.datastore.password }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  value: "{{ .Values.datastore.password }}"
+{{- else if .Values.datastore.passwordSecret }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.passwordSecret }}"
+      key: "password"
+{{- end -}}
+{{- if .Values.datastore.username }}
+- name: OPENFGA_DATASTORE_USER
+  value: "{{ .Values.datastore.username }}"
+{{- else if .Values.datastore.usernameSecret }}
+- name: OPENFGA_DATASTORE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.usernameSecret }}"
+      key: "username"
+{{- end }}
+{{- end -}}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -87,32 +87,38 @@ Return true if a secret object should be created
 - name: OPENFGA_DATASTORE_ENGINE
   value: "{{ .Values.datastore.engine }}"
 {{- end }}
-{{- if .Values.datastore.externalSecret.uriSecretKey }}
+{{- if .Values.datastore.uriSecret }}
 - name: OPENFGA_DATASTORE_URI
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.externalSecret.name }}"
-      key: "{{ .Values.datastore.externalSecret.uriSecretKey }}"
+      name: "{{ .Values.datastore.uriSecret }}"
+      key: uri
+{{- else if and (.Values.datastore.existingSecret) (.Values.datastore.secretKeys.uriKey) }}
+- name: OPENFGA_DATASTORE_URI
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.existingSecret }}"
+      key: "{{ .Values.datastore.secretKeys.uriKey }}"
 {{- else if .Values.datastore.uri }}
 - name: OPENFGA_DATASTORE_URI
   value: "{{ .Values.datastore.uri }}"
 {{- end }}
-{{- if .Values.datastore.externalSecret.usernameSecretKey }}
+{{- if and (.Values.datastore.existingSecret) (.Values.datastore.secretKeys.usernameKey) }}
 - name: OPENFGA_DATASTORE_USERNAME
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.externalSecret.name }}"
-      key: "{{ .Values.datastore.externalSecret.usernameSecretKey }}"
+      name: "{{ .Values.datastore.existingSecret }}"
+      key: "{{ .Values.datastore.secretKeys.usernameKey }}"
 {{- else if .Values.datastore.username }}
 - name: OPENFGA_DATASTORE_USERNAME
   value: "{{ .Values.datastore.username }}"
 {{- end }}
-{{- if .Values.datastore.externalSecret.passwordSecretKey }}
+{{- if and (.Values.datastore.existingSecret) (.Values.datastore.secretKeys.passwordKey) }}
 - name: OPENFGA_DATASTORE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.externalSecret.name }}"
-      key: "{{ .Values.datastore.externalSecret.passwordSecretKey }}"
+      name: "{{ .Values.datastore.existingSecret }}"
+      key: "{{ .Values.datastore.secretKeys.passwordKey }}"
 {{- else if .Values.datastore.password }}
 - name: OPENFGA_DATASTORE_PASSWORD
   value: "{{ .Values.datastore.password }}"

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,15 +77,3 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "openfga.datastore.uri" -}}
-{{- if not .Values.datastore.uri -}}
-    {{- if eq datastore.engine "postgresql" }}
-        {{- printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
-    {{- else if eq datastore.engine "mysql" }}
-        {{- printf "%s:%s@tcp(%s:%s)/%s?parseTime=true" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
-    {{- end -}}
-{{- else -}}
-    {{- .Values.datastore.uri | quote -}}
-{{- end }}
-{{- end }}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -77,3 +77,15 @@ Return true if a secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "openfga.datastore.uri" -}}
+{{- if not .Values.datastore.uri -}}
+    {{- if eq datastore.engine "postgresql" }}
+        {{- printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
+    {{- else if eq datastore.engine "mysql" }}
+        {{- printf "%s:%s@tcp(%s:%s)/%s?parseTime=true" .Values.datastore.user .Values.datastore.password .Values.datastore.host .Values.datastore.port .Values.datastore.database | quote }}
+    {{- end -}}
+{{- else -}}
+    {{- .Values.datastore.uri | quote -}}
+{{- end }}
+{{- end }}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -84,34 +84,34 @@ Return true if a secret object should be created
 - name: OPENFGA_DATASTORE_ENGINE
   value: "{{ .Values.datastore.engine }}"
 {{- end }}
-{{- if .Values.datastore.uri }}
-- name: OPENFGA_DATASTORE_URI
-  value: "{{ .Values.datastore.uri}}"
-{{- else if .Values.datastore.uriSecret }}
+{{- if .Values.datastore.externalSecret.uriSecretKey }}
 - name: OPENFGA_DATASTORE_URI
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.uriSecret }}"
-      key: "uri"
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.uriSecretKey }}"
+{{- else if .Values.datastore.uri }}
+- name: OPENFGA_DATASTORE_URI
+  value: "{{ .Values.datastore.uri }}"
 {{- end }}
-{{- if .Values.datastore.password }}
-- name: OPENFGA_DATASTORE_PASSWORD
-  value: "{{ .Values.datastore.password }}"
-{{- else if .Values.datastore.passwordSecret }}
-- name: OPENFGA_DATASTORE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: "{{ .Values.datastore.passwordSecret }}"
-      key: "password"
-{{- end -}}
-{{- if .Values.datastore.username }}
-- name: OPENFGA_DATASTORE_USER
-  value: "{{ .Values.datastore.username }}"
-{{- else if .Values.datastore.usernameSecret }}
+{{- if .Values.datastore.externalSecret.usernameSecretKey }}
 - name: OPENFGA_DATASTORE_USERNAME
   valueFrom:
     secretKeyRef:
-      name: "{{ .Values.datastore.usernameSecret }}"
-      key: "username"
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.usernameSecretKey }}"
+{{- else if .Values.datastore.username }}
+- name: OPENFGA_DATASTORE_USERNAME
+  value: "{{ .Values.datastore.username }}"
+{{- end }}
+{{- if .Values.datastore.externalSecret.passwordSecretKey }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.datastore.externalSecret.name }}"
+      key: "{{ .Values.datastore.externalSecret.passwordSecretKey }}"
+{{- else if .Values.datastore.password }}
+- name: OPENFGA_DATASTORE_PASSWORD
+  value: "{{ .Values.datastore.password }}"
 {{- end }}
 {{- end -}}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not  .Values.autoscaling.enabled }}
   replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory")}}
   {{- end }}
   selector:
@@ -80,43 +80,7 @@ spec:
             {{- end }}
 
           env:
-            {{- if .Values.datastore.engine }}
-            - name: OPENFGA_DATASTORE_ENGINE
-              value: "{{ .Values.datastore.engine }}"
-            {{- end }}
-
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: {{ include "openfga.datastore.uri" . }}
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
-
-            {{- if .Values.datastore.password}}
-            - name: OPENFGA_DATASTORE_PASSWORD
-              value: "{{ .Values.datastore.password }}"
-            {{- else if .Values.datastore.passwordSecret }}
-            - name: OPENFGA_DATASTORE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.passwordSecret }}"
-                  key: "password"
-            {{- end }}
-
-            {{- if .Values.datastore.username }}
-            - name: OPENFGA_DATASTORE_USER
-              value: "{{ .Values.datastore.username }}"
-            {{- else if .Values.datastore.usernameSecret }}
-            - name: OPENFGA_DATASTORE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.userSecret }}"
-                  key: "username"
-            {{- end }}
+            {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -56,20 +56,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args: [ "migrate" ]
           env:
-            {{- if .Values.datastore.engine }}
-            - name: OPENFGA_DATASTORE_ENGINE
-              value: "{{ .Values.datastore.engine }}"
-            {{- end }}
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
+            {{- include "openfga.datastore.envConfig" . | nindent 12 }}
             {{- if .Values.migrate.timeout }}
             - name: OPENFGA_TIMEOUT
               value: "{{ .Values.migrate.timeout }}"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -109,7 +109,6 @@ spec:
 
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
-
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE
               value: "{{ .Values.datastore.maxCacheSize }}"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -96,6 +96,28 @@ spec:
                   key: "uri"
             {{- end }}
 
+            {{- if .Values.datastore.password}}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              value: "{{ .Values.datastore.password }}"
+            {{- else if .Values.datastore.passwordSecret }}
+            - name: OPENFGA_DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.passwordSecret }}"
+                  key: "password"
+            {{- end }}
+
+            {{- if .Values.datastore.username }}
+            - name: OPENFGA_DATASTORE_USER
+              value: "{{ .Values.datastore.username }}"
+            {{- else if .Values.datastore.usernameSecret }}
+            - name: OPENFGA_DATASTORE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.datastore.userSecret }}"
+                  key: "username"
+            {{- end }}
+
             {{- if .Values.datastore.maxCacheSize }}
             - name: OPENFGA_DATASTORE_MAX_CACHE_SIZE
               value: "{{ .Values.datastore.maxCacheSize }}"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
 
             {{- if .Values.datastore.uri }}
             - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
+              value: {{ include "openfga.datastore.uri" . }}
             {{- else if .Values.datastore.uriSecret }}
             - name: OPENFGA_DATASTORE_URI
               valueFrom:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -36,21 +36,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args: ["migrate"]
           env:
-            {{- if .Values.datastore.engine }}
-            - name: OPENFGA_DATASTORE_ENGINE
-              value: "{{ .Values.datastore.engine }}"
-            {{- end }}
-
-            {{- if .Values.datastore.uri }}
-            - name: OPENFGA_DATASTORE_URI
-              value: "{{ .Values.datastore.uri }}"
-            {{- else if .Values.datastore.uriSecret }}
-            - name: OPENFGA_DATASTORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.datastore.uriSecret }}"
-                  key: "uri"
-            {{- end }}
+            {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 
             {{- if .Values.migrate.timeout }}
             - name: OPENFGA_TIMEOUT

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -300,19 +300,38 @@
                     ],
                     "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
                 },
-                "usernameSecret": {
+                "existingSecret": {
                     "type": [
                         "string",
                         "null"
                     ],
-                    "description": "the secret name where to get the datastore username, it expects a key named username to exist in the secret"
+                    "description": "the name of an existing secret that contains the datastore uri and credentials"
                 },
-                "passwordSecret": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "the secret name where to get the datastore password, it expects a key named password to exist in the secret"
+                "secretKeys": {
+                    "type": "object",
+                    "properties": {
+                        "uriKey": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "the key in the existing secret mapping to the datastore uri"
+                        },
+                        "usernameKey": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "the key in the existing secret mapping to the datastore username"
+                        },
+                        "passwordKey": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "the key in the existing secret mapping to the datastore password"
+                        }
+                    }
                 },
                 "maxCacheSize": {
                     "type": [

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -274,21 +274,7 @@
                     ],
                     "description": "the URI of the datastore including credentials and database (e.g. postgres://user:password@host:port/dbname)"
                 },
-                "host": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "the host address of the datastore"
-                },
-                "port": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "the port of the datastore"
-                },
-                "user": {
+                "username": {
                     "type": [
                         "string",
                         "null"
@@ -308,6 +294,20 @@
                         "null"
                     ],
                     "description": "the secret name where to get the datastore URI, it expects a key named uri to exist in the secret"
+                },
+                "usernameSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the secret name where to get the datastore username, it expects a key named username to exist in the secret"
+                },
+                "passwordSecret": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the secret name where to get the datastore password, it expects a key named password to exist in the secret"
                 },
                 "maxCacheSize": {
                     "type": [

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -271,7 +271,36 @@
                     "type": [
                         "string",
                         "null"
-                    ]
+                    ],
+                    "description": "the URI of the datastore including credentials and database (e.g. postgres://user:password@host:port/dbname)"
+                },
+                "host": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the host address of the datastore"
+                },
+                "port": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "the port of the datastore"
+                },
+                "user": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the username to authenticate with the datastore"
+                },
+                "password": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "the password to authenticate with the datastore"
                 },
                 "uriSecret": {
                     "type": [

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -189,6 +189,10 @@ telemetry:
 datastore:
   engine: memory
   uri:
+  host:
+  port:
+  user:
+  password:
   uriSecret:
   maxCacheSize:
   maxOpenConns:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -189,11 +189,11 @@ telemetry:
 datastore:
   engine: memory
   uri:
-  host:
-  port:
-  user:
+  username:
   password:
   uriSecret:
+  usernameSecret:
+  passwordSecret:
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -191,9 +191,11 @@ datastore:
   uri:
   username:
   password:
-  uriSecret:
-  usernameSecret:
-  passwordSecret:
+  externalSecret:
+    name: ""
+    uriSecretKey: ""
+    usernameSecretKey: ""
+    passwordSecretKey: ""
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -196,13 +196,14 @@ telemetry:
 datastore:
   engine: memory
   uri:
+  uriSecret:
   username:
   password:
-  externalSecret:
-    name: ""
-    uriSecretKey: ""
-    usernameSecretKey: ""
-    passwordSecretKey: ""
+  existingSecret: ""
+  secretKeys:
+    uriKey: ""
+    usernameKey: ""
+    passwordKey: ""
   maxCacheSize:
   maxOpenConns:
   maxIdleConns:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

## Description
This PR adds additional configuration to setup datastore connection statically and through a secret.

**Our use case:** operating Postgres through the Zalando PG operator which creates secrets in relevant namespaces with username and password to connect to table. We want to automate our deployments as much as possible so copying these secrets manually into a full connection string is not an option.

### Changes:

Adds `datastore.username` and `datastore.password`, mapping to `OPENFGA_DATASTORE_USERNAME` and `OPENFGA_DATASTORE_PASSWORD`.

Allow all connection config to be set through a secret, referenced through `datastore.existingSecret`.

For each field a `datastore.secretKeys.usernameKey|passwordKey|uriKey` can be set. When the secret key is not set, the config will default to the value of `datastore.username|password|uri`.

```yaml
datastore:
  engine: memory
  uri:
  uriSecret:
  username:
  password:
  existingSecret: ""
  secretKeys:
    uriKey: ""
    usernameKey: ""
    passwordKey: ""
```

**Our use case:** setting up URI through static config and the username/password through the secret:

```yaml
datastore:
  engine: postgres
  applyMigrations: true
  migrationType: job
  uri: postgres://pgobelisk.postgresql:5432/openfga
  # Reference to the secret created by pgo
  existingSecret: openfga.openfga.pgobelisk.credentials.postgresql.acid.zalan.do
  secretKeys:
    usernameKey: "username"
    passwordKey: "password"
```

Internally I have put all the datastore config setup into a helper function which then can be invoked in both the job, initcontainer and openfga container sections, so they all use the same config and there is less duplication.

I have also kept the old `uriSecret` as is and made it co-exist with the new setup, so existing deployments don't get broken.

I'm free for input on this and hope this can be added to the main chart, as we have been packaging our own fork for quite some time now.

## References
Stale PR with overlap: https://github.com/openfga/helm-charts/pull/140

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

