### PR TITLE
feat(openfga): Allow extra labels specific to pods

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.podExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -783,6 +783,14 @@
             },
             "default": {}
         },
+        "podExtraLabels": {
+            "type": "object",
+            "description": "Map of labels to add to the pods' manifest",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {}
+        },
         "service": {
             "type": "object",
             "properties": {

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -28,6 +28,7 @@ serviceAccount:
 annotations: {}
 
 podAnnotations: {}
+podExtraLabels: {}
 
 extraEnvVars: []
 extraVolumes: []


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

This PR provides the ability to add labels to openfga pods.

## Description
<!-- Provide a detailed description of the changes -->

Some mechanisms such as Network Policies or Webhooks uses the concept of [LabelSelector](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/). This PR adds a `podExtraLabels` value next to the `podAnnotations` so that extra labels can be added to the openfga pods.

This change was validated through snapshot testing in an internal fork.
There is no testing framework in place here. Providing the mentioned snapshot testing framework is out of this PR's scope so I won't check the last box.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

