### PR TITLE
feat: Allow new datastore implementation to be used

### DIFF
--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -265,11 +265,7 @@
             "properties": {
                 "engine": {
                     "type": "string",
-                    "enum": [
-                        "memory",
-                        "postgres",
-                        "mysql"
-                    ],
+                    "description": "the datastore engine to use, currently openfga supports memory (default), postgres, mysql and sqlite implementations, be sure to adapt your configuration accordingly",
                     "default": "memory"
                 },
                 "uri": {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

This PR removes the limitations of engines to use by OpenFGA.

## Description
<!-- Provide a detailed description of the changes -->

The `/datastore/engine` property get its enumeration restriction removed. Additionally, a description is added to document some engines are supported.

Enables the addition to OpenFGA of a new engine without the requirement of maintaining this chart again to use it.

DOES NOT add full support for additional engines as it will be the responsibility of the chart user to add the necessary configuration (ie: does not manages persistence of a sqlite file storage)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Fixes #171 by allowing the use of the `sqlite` engine name.
This cancelled PR ( https://github.com/openfga/openfga/pull/2005 ) adds support for MSSQL, if this support is added later on, it would also benefit from this PR.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

