### PR TITLE
feat(test): Allow extension of test pod to allow matching local policy

### DIFF
--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -16,4 +16,10 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command: ["grpc_health_probe", '-addr={{ include "openfga.fullname" . }}:{{ (split ":" .Values.grpc.addr)._1 }}']
+      {{- with .Values.testContainerSpec }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   restartPolicy: Never
+  {{- with .Values.testPodSpec }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1024,6 +1024,14 @@
                 }
             }
         },
+        "testPodSpec": {
+            "type": "object",
+            "description": "Extra spec for the test pod to match cluster policy"
+        },
+        "testContainerSpec": {
+            "type": "object",
+            "description": "Extra spec for the test container to match cluster policy"
+        },
         "common": {},
         "extraObjects": {
             "type": "array",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -336,6 +336,9 @@ migrate:
   labels: {}
   timeout:
 
+testPodSpec: {}
+testContainerSpec: {}
+
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates
 extraObjects: []


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Provides the ability to extends the definition of the connection test pod.

## Description
<!-- Provide a detailed description of the changes -->
The helm chart uses a pod to test its correct deployment.
There is no ability to extend the definition of this pod and therefore to make the pod match any policy in place.

Such policy preventing the test pod deployment might be (not exhaustive):
* Resource quota without ability to provide a default value with a limit range
* ValidatingWebhookConfiguration based constraints with products such as kyverno or OPA

Here is a working example of a configuration matching the resource quota constraint :
```yaml
testContainerSpec:
  resources:
    limits:
      cpu: 1
      memory: 250M
    requests:
      cpu: 50m
      memory: 250M
testPodSpec:
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000
    runAsGroup: 1000
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

This feature is documented by the value schemas.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

