### PR TITLE
[Enhancement] More flexibility for defining corsAllowedHeaders and oidc.issuer

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -161,7 +161,7 @@ spec:
             - name: OPENFGA_DATASTORE_CONN_MAX_LIFETIME
               value: "{{ .Values.datastore.connMaxLifetime }}"
             {{- end }}
-            
+
             {{- if .Values.maxConcurrentReadsForCheck }}
             - name: OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK
               value: "{{ .Values.maxConcurrentReadsForCheck }}"
@@ -226,7 +226,8 @@ spec:
 
             {{- if .Values.http.corsAllowedOrigins }}
             - name: OPENFGA_HTTP_CORS_ALLOWED_ORIGINS
-              value: "{{ join "," .Values.http.corsAllowedOrigins }}"
+              value: {{ include "common.tplvalues.render" ( dict "value" (join "," .Values.http.corsAllowedOrigins) "context" $ ) }}
+
             {{- end }}
 
             {{- if .Values.http.corsAllowedHeaders }}
@@ -251,7 +252,7 @@ spec:
 
             {{- if .Values.authn.oidc.issuer }}
             - name: OPENFGA_AUTHN_OIDC_ISSUER
-              value: "{{ .Values.authn.oidc.issuer }}"
+              value: "{{ include "common.tplvalues.render" ( dict "value" .Values.authn.oidc.issuer "context" $ ) }}"
             {{- end }}
 
             - name: OPENFGA_PLAYGROUND_ENABLED


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR introduces the usage of the `common.tplvalues.render` helper function to give more flexibility when deploying the chart in multiple environments.

## References

No reference yet.

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above] -> No doc section available for the deployment template
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected -> No unittests available, but  tested manually

