### PR TITLE
fix: add the missing default value for datastore.migrationType

### DIFF
--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -204,6 +204,7 @@ datastore:
   connMaxLifetime:
   applyMigrations: true
   waitForMigrations: true
+  migrationType: job
   migrations:
     resources: {}
     image:


### PR DESCRIPTION
## Description
The values.schema.json sets the default value of datastore.migrationType to job, but this attribute is missing in the values.yaml file.

## References
N/A

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

