### PR TITLE
feat: Alternatively allow specifying a secret to define a comma-separated list of pre-shared keys.

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -244,6 +244,14 @@ spec:
               value: "{{ join "," .Values.authn.preshared.keys }}"
             {{- end }}
 
+            {{- if .Values.authn.preshared.keysSecret }}
+            - name: OPENFGA_AUTHN_PRESHARED_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.authn.preshared.keysSecret }}"
+                  key: "presharedKeys"
+            {{- end }}
+
             {{- if .Values.authn.oidc.audience }}
             - name: OPENFGA_AUTHN_OIDC_AUDIENCE
               value: "{{ .Values.authn.oidc.audience }}"


### PR DESCRIPTION

# Improvement proposal: allow to defined preshared keys in a secret

## Intro

Using OpenFGA with the "pre-shared" authentication mode requires defining API keys in the values file.

## Proposal

Alternatively allow specifying a secret to define a comma-separated list of pre-shared keys.

```
{{- if .Values.authn.preshared.keysSecret }}
- name: OPENFGA_AUTHN_PRESHARED_KEYS
    valueFrom:
    secretKeyRef:
        name: "{{ .Values.authn.preshared.keysSecret }}"
        key: "presharedKeys"
{{- end }}
```

## Testing

Tested locally on minikube as follows

### Testing the configuration with preshared.keys (on clear)

```
helm install openfga ./openfga \
  --set datastore.engine=mysql \
  --set datastore.uri="root:password@tcp(openfga-mysql.default.svc.cluster.local:3306)/mysql?parseTime=true" \
  --set datastore.applyMigrations=true \
  --set datastore.waitForMigrations=true \
  --set datastore.migrationType=initContainer \
  --set mysql.enabled=true \
  --set mysql.auth.rootPassword=password \
  --set mysql.auth.database=mysql \
  --set authn.method=preshared \
  --set-json authn.preshared.keys='["key1"]'
```

Port forwarding for testing

```
  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=openfga,app.kubernetes.io/instance=openfga" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace default $POD_NAME -o jsonpath="{.spec.containers[0].ports[1].containerPort}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace default port-forward $POD_NAME 8080:$CONTAINER_PORT
```

Testing an endpoint

```
curl --location 'http://localhost:8080/stores' --header 'Authorization: Bearer key1'
{"stores":[], "continuation_token":""}
curl --location 'http://localhost:8080/stores' --header 'Authorization: Bearer key2'
{"code":"unauthenticated","message":"unauthenticated"}
```

### Testing the configuration with preshared.keys (on clear)


Define the secret

```
kubectl create secret -n default generic openfga-secrets --from-literal=presharedKeys=key1,key2
```

Install openfga with presahred (run if you have the previous running instance ```helm uninstall openfga```)

```
helm install openfga ./openfga \
  --set datastore.engine=mysql \
  --set datastore.uri="root:password@tcp(openfga-mysql.default.svc.cluster.local:3306)/mysql?parseTime=true" \
  --set datastore.applyMigrations=true \
  --set datastore.waitForMigrations=true \
  --set datastore.migrationType=initContainer \
  --set mysql.enabled=true \
  --set mysql.auth.rootPassword=password \
  --set mysql.auth.database=mysql  \
  --set authn.method=preshared  \
  --set authn.preshared.keysSecret=openfga-secrets

```

Testing an endpoint (user the port-forwarding statement defined before)

```
curl --location 'http://localhost:8080/stores' --header 'Authorization: Bearer key1'
{"stores":[], "continuation_token":""}
curl --location 'http://localhost:8080/stores' --header 'Authorization: Bearer key2'
{"stores":[], "continuation_token":""}
curl --location 'http://localhost:8080/stores' --header 'Authorization: Bearer key3'
{"code":"unauthenticated","message":"unauthenticated"}
```

