### PR TITLE
feat: allow usage of existing secret for preshared keys

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -246,6 +246,12 @@ spec:
             {{- if .Values.authn.preshared.keys }}
             - name: OPENFGA_AUTHN_PRESHARED_KEYS
               value: "{{ join "," .Values.authn.preshared.keys }}"
+            {{- else if .Values.authn.preshared.keysSecret }}
+            - name: OPENFGA_AUTHN_PRESHARED_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.authn.preshared.keysSecret }}"
+                  key: "presharedKeys"
             {{- end }}
 
             {{- if .Values.authn.oidc.audience }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -506,6 +506,13 @@
                                 "type": "string",
                                 "minItems": 1
                             }
+                        },
+                        "keysSecret": {
+                          "type": [
+                              "string",
+                              "null"
+                          ],
+                          "description": "the secret name where to get the preshared keys, it expects a key named 'presharedKeys' to exist in the secret containing a comma-separated list of keys"
                         }
                     }
                 },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -242,7 +242,11 @@ http:
 authn:
   method:
   preshared:
+    # Specify a list of preshared keys directly:
     keys: []
+    # Or reference a secret that contains a list of preshared keys:
+    # Secret should have a "presharedKeys" key
+    # keysSecret: "my-preshared-keys-secret"
   oidc:
     audience:
     issuer:


### PR DESCRIPTION
## Summary
Allow usage of existing secret that contains the pre-shared keys.

## Description
Extending the Helm chart with the option to read the pre-shared keys from a Kubernetes secret.
The secret is expected to have the `presharedKeys` key which will contain the keys themselves.
The functionality is the same as for `datastore.uriSecret`.

## References
https://github.com/openfga/helm-charts/issues/175
https://github.com/openfga/helm-charts/pull/188