### PR TITLE
fix:(openfga) OPENFGA_TRACE_OTLP_TLS_ENABLED stringify value

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -390,7 +390,7 @@ spec:
 
             {{- if .Values.telemetry.trace.otlp.tls.enabled }}
             - name: OPENFGA_TRACE_OTLP_TLS_ENABLED
-              value: {{ .Values.telemetry.trace.otlp.tls.enabled }}
+              value: "{{ .Values.telemetry.trace.otlp.tls.enabled }}"
             {{- end }}
 
             {{- if .Values.telemetry.trace.sampleRatio }}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -30,6 +30,13 @@ annotations: {}
 podAnnotations: {}
 podExtraLabels: {}
 
+# Extra env variables to pass to the containers
+# Usage Example:
+#   extraEnvVars:
+#     - name: OPENFGA_CACHE_CONTROLLER_ENABLED
+#       value: "true"
+#     - name: OPENFGA_CACHE_CONTROLLER_TTL
+#       value: 1s
 extraEnvVars: []
 extraVolumes: []
 extraVolumeMounts: []


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Stringify the 'value' for the OPENFGA_TRACE_OTLP_TLS_ENABLED bool

## Description
This change just adds double quotes around the 'value' for the OPENFGA_TRACE_OTLP_TLS_ENABLED variable.  It also adds usage example in the values.yaml for extraEnvVars.

This change has been deployed to an AWS EKS cluster running kubernetes 1.32 and chart version 0.2.23.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

