### PR TITLE
fix(schema): Add enable-access-control to experimental array

### DIFF
--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -627,7 +627,7 @@
             "type": "array",
             "description": "a list of experimental features to enable",
             "default": [],
-            "examples": ["enable-list-users","enable-access-control"],
+            "examples": ["enable-check-optimizations","enable-access-control"],
             "items": {
                 "type": "string",
                 "enum": ["enable-check-optimizations","enable-access-control"]

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -630,7 +630,7 @@
             "examples": ["enable-list-users","enable-access-control"],
             "items": {
                 "type": "string",
-                "enum": ["enable-list-users","enable-access-control"]
+                "enum": ["enable-check-optimizations","enable-access-control"]
             }
         },
         "maxTuplesPerWrite": {

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -627,10 +627,10 @@
             "type": "array",
             "description": "a list of experimental features to enable",
             "default": [],
-            "examples": ["enable-list-users"],
+            "examples": ["enable-list-users","enable-access-control"],
             "items": {
                 "type": "string",
-                "enum": ["enable-list-users"]
+                "enum": ["enable-list-users","enable-access-control"]
             }
         },
         "maxTuplesPerWrite": {


### PR DESCRIPTION
## Description
I want to activate the access-control experimental feature, but the json schema don't allow it. 

## References
https://openfga.dev/docs/getting-started/setup-openfga/access-control#i-enable-access-control-in-the-server

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected -> Yes is activate it

