### PR TITLE
bug: Allow disabling the http service and metrics with helm

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -201,10 +201,8 @@ spec:
               value: {{ .Values.grpc.tls.key }}
             {{- end }}
 
-            {{- if .Values.http.enabled }}
             - name: OPENFGA_HTTP_ENABLED
               value: "{{ .Values.http.enabled }}"
-            {{- end }}
 
             {{- if .Values.http.addr }}
             - name: OPENFGA_HTTP_ADDR
@@ -363,10 +361,8 @@ spec:
               value: "{{ .Values.allowEvaluating1_0Models }}"
             {{- end }}
 
-            {{- if .Values.telemetry.metrics.enabled }}
             - name: OPENFGA_METRICS_ENABLED
               value: "{{ .Values.telemetry.metrics.enabled }}"
-            {{- end }}
 
             {{- if .Values.telemetry.metrics.addr }}
             - name: OPENFGA_METRICS_ADDR


### PR DESCRIPTION
## Description
Gating the `OPENFGA_HTTP_ENABLED` and `OPENFGA_METRICS_ENABLED` blocks means that when the value is set to false, the env vars are not set. This causes the deployment to use the default values for these configs which is `Enabled: true`. Instead we should do the same thing as we do in the `OPENFGA_PLAYGROUND_ENABLED` env var and always set it so that these can be disabled by helm users.

## References
N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

