### PR TITLE
bug: Update default probes to work with tls enabled

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -402,24 +402,57 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- if .Values.grpc.tls.enabled }}
             exec:
-              command: ["grpc_health_probe", "-addr={{ .Values.grpc.addr }}"]
+              command:
+              - grpc_health_probe
+              - -addr={{ .Values.grpc.addr }}
+              - -tls
+              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
+              - -tls-client-cert={{ .Values.grpc.tls.cert }}
+              - -client-tls-key={{ .Values.grpc.tls.key }}
+          {{- else }}
+            grpc:
+              port: {{ (split ":" .Values.grpc.addr)._1 }}
+          {{- end }}
           {{- end }}
 
           {{- if .Values.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- if .Values.grpc.tls.enabled }}
+            exec:
+              command:
+              - grpc_health_probe
+              - -addr={{ .Values.grpc.addr }}
+              - -tls
+              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
+              - -tls-client-cert={{ .Values.grpc.tls.cert }}
+              - -tls-client-key={{ .Values.grpc.tls.key }}
+          {{- else }}
             grpc:
               port: {{ (split ":" .Values.grpc.addr)._1 }}
+          {{- end }}
           {{- end }}
 
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+          {{- if .Values.grpc.tls.enabled }}
+            exec:
+              command:
+              - grpc_health_probe
+              - -addr={{ .Values.grpc.addr }}
+              - -tls
+              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
+              - -tls-client-cert={{ .Values.grpc.tls.cert }}
+              - -tls-client-key={{ .Values.grpc.tls.key }}
+          {{- else }}
             grpc:
               port: {{ (split ":" .Values.grpc.addr)._1 }}
+          {{- end }}
           {{- end }}
 
           resources:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -402,6 +402,13 @@
                             "description": "enables or disables transport layer security (TLS)",
                             "default": false
                         },
+                        "ca": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "the (absolute) file path of the CA certificate to use for the TLS connection"
+                        },
                         "cert": {
                             "type": [
                                 "string",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -227,6 +227,7 @@ grpc:
     enabled: false
     cert:
     key:
+    ca:
 
 http:
   enabled: true


### PR DESCRIPTION
## Description
The k8s native grpc probes don't support tls so we need to use the exec version if tls is enabled. While users can always specify custom probes, this updates the defaults so that things work out of the box for most usecases.

## References
Fixes #3

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

