### PR TITLE
feat: add topology constraints support

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -455,3 +455,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (semverCompare ">=1.18.0" .Capabilities.KubeVersion.Version) }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -115,6 +115,11 @@
             "description": "Specifies the pod toleration constraints for the pod managed by the deployment. For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.",
             "default": []
         },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Specifies the topology spread to control how the pods are spread across your cluster. For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/.",
+            "default": []
+        },
         "serviceAccount": {
             "type": "object",
             "properties": {

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -317,6 +317,8 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}
 
 # @param sidecars Add additional sidecar containers to the pods


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR introduces support for `TopologySpreadConstraints` for Kubernetes version >1.18.0 that we can customize to improve pods spread, leading to high availability.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

