### PR TITLE
bug: Fix typo for probe

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -385,7 +385,7 @@ spec:
               - -tls
               - -tls-ca-cert={{ .Values.grpc.tls.ca }}
               - -tls-client-cert={{ .Values.grpc.tls.cert }}
-              - -client-tls-key={{ .Values.grpc.tls.key }}
+              - -tls-client-key={{ .Values.grpc.tls.key }}
           {{- else }}
             grpc:
               port: {{ (split ":" .Values.grpc.addr)._1 }}


### PR DESCRIPTION
## Description
It seems like there was a typo in one of the flags in #205. This fixes the issue.

## References
See #205

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

