### PR TITLE
feat: add requestTimeout configuration value

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -306,6 +306,11 @@ spec:
               value: "{{ .Values.listUsersMaxResults }}"
             {{- end }}
 
+            {{- if .Values.requestTimeout }}
+            - name: OPENFGA_REQUEST_TIMEOUT
+              value: "{{ .Values.requestTimeout }}"
+            {{- end}}
+
             {{- if .Values.checkQueryCache.enabled }}
             - name: OPENFGA_CHECK_QUERY_CACHE_ENABLED
               value: "{{ .Values.checkQueryCache.enabled }}"

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -805,6 +805,19 @@
             ],
             "description": "the maximum results to return in ListUsers responses"
         },
+        "requestTimeout": {
+          "type": [
+              "string",
+              "null"
+          ],
+          "description": "The timeout duration for a request.",
+          "format": "duration",
+          "examples": [
+              "3s",
+              "1m",
+              "200ms"
+          ]
+        },
         "requestDurationDatastoreQueryCountBuckets": {
             "description": "datastore query count buckets used to label the histogram metric for measuring request duration.",
             "type": "array",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -288,6 +288,7 @@ listObjectsDeadline:
 listObjectsMaxResults:
 listUsersDeadline:
 listUsersMaxResults:
+requestTimeout:
 requestDurationDatastoreQueryCountBuckets: [50, 200]
 allowWriting1_0Models:
 allowEvaluating1_0Models:


### PR DESCRIPTION
Add `requestTimeout` value.

## Description
Adds `requestTimeout` to the values which maps to OpenFGA's `requestTimeout`/ OPENFGA_REQUEST_TIMEOUT option:
https://openfga.dev/docs/getting-started/setup-openfga/configuration#list-of-options

This is actually necessary to fully support the `listObjectsDeadline` option because OpenFGA will return an error on startup if the value of `listObjectsDeadline` < `requestTimeout`.

```
panic: configured request timeout (6s) cannot be lower than 'listObjectsDeadline' config (30s)
```

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above] -> I have added a description to the values schema.
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected -> There is no place to add tests in this repository, as far as I can see.

