### PR TITLE
feat(authn): add support for fetching preshared keys from secrets

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -216,7 +216,13 @@ spec:
               value: {{ .Values.authn.method }}
             {{- end }}
 
-            {{- if .Values.authn.preshared.keys }}
+            {{- if .Values.authn.preshared.keysSecret }}
+            - name: OPENFGA_AUTHN_PRESHARED_KEYS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.authn.preshared.keysSecret | quote }}
+                  key: keys
+            {{- else if .Values.authn.preshared.keys }}
             - name: OPENFGA_AUTHN_PRESHARED_KEYS
               value: "{{ join "," .Values.authn.preshared.keys }}"
             {{- end }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -217,7 +217,7 @@ spec:
             {{- end }}
 
             {{- if .Values.authn.preshared.keysSecret }}
-            - name: OPENFGA_AUTHN_PRESHARED_KEYS_SECRET
+            - name: OPENFGA_AUTHN_PRESHARED_KEYS
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.authn.preshared.keysSecret | quote }}

--- a/charts/openfga/templates/tests/test-auth-secret.yaml
+++ b/charts/openfga/templates/tests/test-auth-secret.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "openfga.fullname" . }}-test-auth-secret"
+  labels:
+    {{- include "openfga.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test-auth
+      image: "busybox" 
+      command: 
+        - "/bin/sh"
+        - "-ec"  # Adding -e to fail on error, -c to run command
+        - |
+          echo "Starting auth secret test..."
+          
+          # Check if secret is mounted
+          if [ -z "$OPENFGA_AUTHN_PRESHARED_KEYS_SECRET" ]; then
+            echo "ERROR: OPENFGA_AUTHN_PRESHARED_KEYS_SECRET environment variable is not set"
+            exit 1
+          fi
+          
+          echo "Secret environment variable is set to: $OPENFGA_AUTHN_PRESHARED_KEYS_SECRET"
+          echo "Test completed successfully"
+      env:
+        - name: OPENFGA_AUTHN_PRESHARED_KEYS_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: test-auth-secret
+              key: keys
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-auth-secret
+  labels:
+    {{- include "openfga.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"  # Ensure secret is created before the test pod
+type: Opaque
+data:
+  keys: {{ "test-key-1,test-key-2" | b64enc }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -571,6 +571,13 @@
                                 "type": "string",
                                 "minItems": 1
                             }
+                        },
+                        "keysSecret": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "the secret name where to get the preshared keys, expects a key named keys to exist in the secret. Keys should be comma separated"
                         }
                     }
                 },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -251,6 +251,7 @@ authn:
   method:
   preshared:
     keys: []
+    keysSecret:
   oidc:
     audience:
     issuer:


### PR DESCRIPTION
Previously, preshared keys were only configurable directly through values.yaml, this change adds the ability to fetch preshared keys from Kubernetes secrets instead.

The new keysSecret field in the authn.preshared configuration allows specifying a secret name that contains the keys.

## Description
This PR adds a new security enhancement to the Helm chart that allows fetching preshared authentication keys from Kubernetes secrets instead of storing them directly in values.yaml.

Key changes:
- Added `keysSecret` field to `authn.preshared` configuration in values.schema.json
- Updated deployment.yaml to support reading keys from the specified secret
- Keys in the secret should be comma-separated in the `keys` field

This change follows the same pattern as `datastore.uriSecret`. 

## References
[#175](https://github.com/openfga/helm-charts/issues/175)
[#188](https://github.com/openfga/helm-charts/pull/188)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) (Will create another PR for the docs and update this PR)
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

