### PR TITLE
allow =>1.18 eks pre-release versions to render topology constraints

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -468,7 +468,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (semverCompare ">=1.18.0" .Capabilities.KubeVersion.Version) }}
+      {{- if (semverCompare ">=1.18.0" (.Capabilities.KubeVersion.Version | splitList "-" | first)) }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Pre-release versions for EKS are not respecting version constraints which means pre-release versions that are higher than 1.18 are not rendering topology constraints in `deployment.yaml`. 

This change fixes that by comparing the semantic versioning before the pre-release version. 

## Description
<!-- Provide a detailed description of the changes -->
We introduce a small change that allows `semverCompare` to parse only the first major|minor|patch values.

## Testing
- Add `topologySpreadConstraints` to `values.yaml`:

```

topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: openfga

```
- Setup environment:
```
helm repo add bitnami https://charts.bitnami.com/bitnami
helm dependency update
```
- Test
```
helm template openfga . --kube-version "v1.31.6-eks-bc803b4" #  renders topologySpreadConstraints
helm template openfga . --kube-version "v1.31.6"  # renders
helm template openfga . --kube-version "v1.31"  # renders
helm template openfga . --kube-version "v1"  # does not render
helm template openfga . --kube-version "v1.18" # renders
helm template openfga . --kube-version "v1.17"  # does not render
helm template openfga . --kube-version "1.18" # renders
```

## References

## Review Checklist

- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

