### PR TITLE
feat: add extraEnv configuration for additional environment variables

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             {{- with .Values.extraEnvVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
           {{- with .Values.migrate.extraVolumeMounts }}
@@ -382,6 +385,10 @@ spec:
 
             {{- with .Values.extraEnvVars }}
               {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
             {{- end }}
 
           {{- if .Values.customReadinessProbe }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1145,6 +1145,11 @@
             "type": "boolean",
             "description": "This value is not used by this chart, but allows a common pattern of enabling/disabling subchart dependencies (where OpenFGA is a subchart)",
             "default": false
+        },
+        "extraEnv": {
+            "type": "string",
+            "description": "Extra environment variables to add to the deployment's main container (interpreted as a template with helm 'tpl' syntax)",
+            "default": ""
         }
     },
     "additionalProperties": false

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -368,3 +368,22 @@ extraObjects: []
 #     instances: 3
 #     storage:
 #       size: 10Gi
+
+# additional environment variables to be passed to the OpenFGA
+extraEnv: ""
+## Example: add some extra environment variables from different places
+#extraEnv: |
+# - name: OPENFGA_DATASTORE_USERNAME
+#   valueFrom:
+#     configMapKeyRef:
+#       name: {{ .Release.Name }}-openfga
+#       key: username
+# - name: OPENFGA_DATASTORE_PASSWORD
+#   valueFrom:
+#     secretKeyRef:
+#       name: {{ .Release.Name }}-openfga
+#       key: password
+# - name: OPENFGA_DATASTORE_URI
+#   value: "postgresql://{{ .Release.Name }}-openfga-postgresql:5432/openfga?sslmode=disable"
+# - name: OPENFGA_LOG_LEVEL
+#   value: "debug"


### PR DESCRIPTION
## Description

as much as I like PR #212 I think it doesn't solve more general problem which is "there is so many options people need to provide secrets". 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) - nope, I do not see anything about helm charts there
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected - I didn't. I believe simple container verifying that there is some secret present when I add secret, tests kubernetes, not this helm chart. Saying that I did manually executed `helm template -n test-01 openfga .` with example configuration uncommented and I got expected result: 

```yaml
---
# Source: openfga/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
...
            - name: OPENFGA_METRICS_ADDR
              value: "0.0.0.0:2112"
            - name: OPENFGA_DATASTORE_USERNAME
              valueFrom:
                configMapKeyRef:
                  name: openfga-openfga
                  key: username
            - name: OPENFGA_DATASTORE_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: openfga-openfga
                  key: password
            - name: OPENFGA_DATASTORE_URI
              value: "postgresql://openfga-openfga-postgresql:5432/openfga?sslmode=disable"
            - name: OPENFGA_LOG_LEVEL
              value: "debug"
            
          readinessProbe:
...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying additional environment variables using a new configuration option.
  * Users can now define extra environment variables with Helm templating for both the main application and database migration containers.

* **Documentation**
  * Included example configurations for adding environment variables via the new option in the values file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->