### PR TITLE
fix: Allow OpenFGA to be enable/disabled as a subchart

### DIFF
--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1142,5 +1142,10 @@
             "default": []
         }
     },
+    "enabled": {
+        "type": "boolean",
+        "description": "This value is not used by this chart, but allows a common pattern of enabling/disabling subchart dependencies (where OpenFGA is a subchart)",
+        "default": false
+    },
     "additionalProperties": false
 }


### PR DESCRIPTION
This allows the common pattern (as even used by OpenFGA for its PostgreSQL and MySQL subcharts) for enabling or disabling a subchart, **for charts that pull in OpenFGA as a subchart**, which is otherwise disallowed by OpenFGA's `additionalProperties: false` schema.

With regards to choosing the default of "false": this value is not used by this chart, and should not introduce any breaking changes since, since, given the current schema, no one could have been using it yet! Other than that, I went with "false" since it pattern the defaults OpenFGA itself uses when pulling in its optional subcharts.

... example Chart.yaml including OpenFGA as a subchart:

```yaml
dependencies:
  - name: openfga
    repository: https://openfga.github.io/helm-charts
    version: ~0.2.35
    condition: openfga.enabled                                                                                                                                                                                 ```

Current behavior:

```text
helm lint charts/mychart
==> Linting charts/mychart
[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
openfga:
- (root): Additional property enabled is not allowed
```

## Workarounds

It's possible for the parent chart to use an arbitrary value _not_ nested under the openfga prefix, e.g. `openfga_enabled` instead of `openfga.enabled`, but using `<subchart>.enabled` seems to be a universal pattern.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
  - (n/a)
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
