### PR TITLE
chore(ci): restrict lint & test workflow permissions to only read contents

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Lint and Test Charts
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/helm-charts/security/code-scanning/1](https://github.com/openfga/helm-charts/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs tests/linting, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` and before the `on` key. This will apply the least privilege principle to all jobs in the workflow without changing any existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
