### PR TITLE
feat: add an option to change the startup command/args for the app

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -60,8 +60,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: {{ .Values.datastore.migrations.command }}
-          args: {{ .Values.datastore.migrations.args }}
+          command:
+            {{- toYaml .Values.datastore.migrations.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.datastore.migrations.args | nindent 12 }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
             {{- if .Values.migrate.timeout }}
@@ -91,8 +93,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: {{ .Values.command }}
-          args: {{ .Values.args }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
           ports:
             - name: grpc
               containerPort: {{ (split ":" .Values.grpc.addr)._1 }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -60,7 +60,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          args: [ "migrate" ]
+          command: {{ .Values.migrations.command }}
+          args: {{ .Values.migrations.args }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
             {{- if .Values.migrate.timeout }}
@@ -90,7 +91,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["run"]
+          command: {{ .Values.command }}
+          args: {{ .Values.args }}
           ports:
             - name: grpc
               containerPort: {{ (split ":" .Values.grpc.addr)._1 }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: {{ .Values.migrations.command }}
-          args: {{ .Values.migrations.args }}
+          command: {{ .Values.datastore.migrations.command }}
+          args: {{ .Values.datastore.migrations.args }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
             {{- if .Values.migrate.timeout }}

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -39,8 +39,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: {{ .Values.datastore.migrations.command }}
-          args: {{ .Values.datastore.migrations.args }}
+          command:
+            {{- toYaml .Values.datastore.migrations.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.datastore.migrations.args | nindent 12 }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -39,7 +39,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          args: ["migrate"]
+          command: {{ .Values.migrations.command }}
+          args: {{ .Values.migrations.args }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -39,8 +39,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: {{ .Values.migrations.command }}
-          args: {{ .Values.migrations.args }}
+          command: {{ .Values.datastore.migrations.command }}
+          args: {{ .Values.datastore.migrations.args }}
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
 

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1150,7 +1150,7 @@
             "type": "array",
             "description": "Command for starting the main container",
             "items": {
-                "type": "object"
+                "type": "string"
             },
             "default": ["/openfga"]
         },
@@ -1158,7 +1158,7 @@
             "type": "array",
             "description": "Arguments for starting the main container",
             "items": {
-                "type": "object"
+                "type": "string"
             },
             "default": ["run"]
         }

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1145,6 +1145,22 @@
             "type": "boolean",
             "description": "This value is not used by this chart, but allows a common pattern of enabling/disabling subchart dependencies (where OpenFGA is a subchart)",
             "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Command for starting the main container",
+            "items": {
+                "type": "object"
+            },
+            "default": ["/openfga"]
+        },
+        "args": {
+            "type": "array",
+            "description": "Arguments for starting the main container",
+            "items": {
+                "type": "object"
+            },
+            "default": ["run"]
         }
     },
     "additionalProperties": false

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -118,6 +118,9 @@ service:
   type: ClusterIP
   port: 8080
 
+command: ["/openfga"]
+args: ["run"]
+
 telemetry:
   trace:
     enabled: false
@@ -215,6 +218,8 @@ datastore:
   migrationType: job
   migrations:
     resources: {}
+    command: ["/openfga"]
+    args: ["migrate"]
     image:
       repository: groundnuty/k8s-wait-for
       pullPolicy: Always


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Adding the flexibility to overwrite current startup commands for flexibility. 
#### What problem is being solved?
https://github.com/openfga/helm-charts/issues/101

#### How is it being solved?
Simply by making `command` and `args` parameters
#### What changes are made to solve it?
add an option to change the startup command/args for the app

#### Wanted Behaviour:
```
    datastore:
      engine: postgres
      migrationType: initContainer
      migrations:
        command:
          - /bin/sh
          - "-c"
        args:
          - source /vault/secrets/db.env && exec /openfga migrate
    podAnnotations:
      vault.hashicorp.com/agent-inject: "true"
      vault.hashicorp.com/role: "app-role"
      vault.hashicorp.com/agent-pre-populate-only: "true"
      vault.hashicorp.com/agent-inject-secret-db.env: "kv/data/openfga/db"
      vault.hashicorp.com/agent-inject-template-db.env: |
        {{- with secret "kv/data/openfga/db" -}}
        export OPENFGA_DATASTORE_URI="postgres://{{ .Data.data.user }}:{{ .Data.data.pass }}@postgres.postgres.svc.cluster.local:5432/openfga"
        {{- end }}
    command:
      - /bin/sh
      - "-c"
    args:
      - source /vault/secrets/db.env && exec /openfga run
```
## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Helm values to configure startup command and arguments for the main application container and database migration jobs.
  * Defaults preserve prior behavior (command: /openfga; args: run for app, migrate for migrations), while enabling overrides as needed.

* Chores
  * Updated chart templates and values schema to support the new configurable command and args options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->