### PR TITLE
feat: add option to specify the clusterIP of OpenFGA service

### DIFF
--- a/charts/openfga/templates/service.yaml
+++ b/charts/openfga/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - name: grpc
       port: {{ (split ":" .Values.grpc.addr)._1 }}
@@ -17,7 +20,7 @@ spec:
       protocol: TCP
 
     {{- if .Values.http.enabled }}
-    - name: http 
+    - name: http
       port: {{ (split ":" .Values.http.addr)._1 }}
       targetPort: http
       protocol: TCP

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -116,6 +116,7 @@ customStartupProbe: {}
 service:
   annotations: {}
   type: ClusterIP
+  clusterIP: None
   port: 8080
 
 telemetry:

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -116,7 +116,6 @@ customStartupProbe: {}
 service:
   annotations: {}
   type: ClusterIP
-  clusterIP: None
   port: 8080
 
 telemetry:


### PR DESCRIPTION
Adds the option to specify the ClusterIP of the OpenFGA service. This allows running OpenFGA as a "headless service" (see https://kubernetes.io/docs/concepts/services-networking/service/#headless-services).

#### What problem is being solved?

We want to run OpenFGA as a headless service, so we can do client-side load balancing of our gRPC connection (which requires discovering the IPs of the individual replicas).

#### How is it being solved?

Adds `service.clusterIP` entry to values.yaml and sets the service specification accordingly.

#### What changes are made to solve it?

- New `clusterIP` setting in values.yaml
- If clusterIP is set, the service specification uses it


## References
* closes https://github.com/openfga/helm-charts/issues/263

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above] -> no additional documentation necessary
- [x] The correct base branch is being used, if not `main`
- [] I have added tests to validate that the change in functionality is working as expected -> I don't see where I would add an automated test but I have tested it locally.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service now supports configurable clusterIP; when unspecified, defaults to a headless Service (clusterIP: None) to improve compatibility with stateful/discovery setups.
* **Chores**
  * Minor YAML formatting cleanup for the HTTP port name with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->