### PR TITLE
feat: Allow Setting Image Registry and Pull Secrets Globally

### DIFF
--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 9.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.3
-digest: sha256:a152c0abc09cadc6a2158e237b67485b3177d1ed8ad9b7f0b64af300b4eb6e25
-generated: "2025-03-27T13:49:29.005097735+01:00"
+  version: 2.31.4
+digest: sha256:2e4dba7715f62620b42b8f1f021e1d1def80fbf6c22052d3d12fca4cf3875780
+generated: "2025-10-15T17:08:29.453093-04:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: common
-    version: "2.13.3"
+    version: "2.31.4"
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -141,3 +141,23 @@ Return true if a secret object should be created
       key: "password"
 {{- end -}}
 {{- end -}}
+
+{{- define "openfga.pullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image .Values.initContainer) "context" $) -}}
+{{- end }}
+
+{{/*
+Job does not use the initContainer image, so by the least-priviledge principle, we do not need to include its pull
+secrets.
+*/}}
+{{- define "openfga.jobPullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) -}}
+{{- end }}
+
+{{- define "openfga.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global "chart" .Chart) -}}
+{{- end }}
+
+{{- define "openfga.initContainer.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.initContainer "global" .Values.global) -}}
+{{- end }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -30,10 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "openfga.pullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -43,7 +40,7 @@ spec:
         - name: wait-for-migration
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.initContainer.repository }}:{{ .Values.initContainer.tag }}"
+          image: {{- include "openfga.initContainer.image" . }}
           imagePullPolicy: {{ .Values.initContainer.pullPolicy }}
           args: ["job-wr", '{{ include "openfga.fullname" . }}-migrate']
           resources:
@@ -56,7 +53,7 @@ spec:
         - name: migrate-database
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "openfga.image" . }}
           args: [ "migrate" ]
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}
@@ -85,7 +82,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "openfga.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["run"]
           ports:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -25,10 +25,7 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end}}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "openfga.jobPullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "openfga.serviceAccountName" . }}
       {{- with .Values.migrate.extraInitContainers }}
       initContainers:
@@ -38,7 +35,7 @@ spec:
         - name: migrate-database
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "openfga.image" . }}
           args: ["migrate"]
           env:
             {{- include "openfga.datastore.envConfig" . | nindent 12 }}

--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -7,13 +7,10 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  {{- with .Values.imagePullSecrets }}
-  imagePullSecrets:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
+  {{- include "openfga.pullSecrets" . | nindent 2 }}
   containers:
     - name: grpc-health-probe
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: {{ include "openfga.image" . }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command: ["grpc_health_probe", '-addr={{ include "openfga.fullname" . }}:{{ (split ":" .Values.grpc.addr)._1 }}']
       {{- with .Values.testContainerSpec }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -3,11 +3,26 @@
     "type": "object",
     "properties": {
         "global": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "The container image registry to pull images from. It is prepended to individual components repositories. For example, if global.imageRegistry is set to 'ghcr.io' and image.repository is set to 'openfga/openfga', the final image repository will be 'ghcr.io/openfga/openfga'."
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "An optional list of references to secrets in the same namespace to use for pulling any of the images used by the pod spec. If specified, these secrets will be passed to individual puller implementations for them to use. For more information see https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod."
+                }
+            },
+            "additionalProperties": true
         },
         "image": {
             "type": "object",
             "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "The container image registry to pull the main OpenFGA image from. It is prepended to the image.repository. For example, if image.registry is set to 'ghcr.io' and image.repository is set to 'openfga/openfga', the final image repository will be 'ghcr.io/openfga/openfga'."
+                },
                 "repository": {
                     "type": "string",
                     "description": "The container repository to pull the main OpenFGA image from",
@@ -17,10 +32,18 @@
                     "type": "string",
                     "description": "Overrides the image tag of the main OpenFGA image whose default is the chart appVersion"
                 },
+                "digest": {
+                    "type": "string",
+                    "description": "Overrides the image digest of the main OpenFGA image. Takes precedence over tag."
+                },
                 "pullPolicy": {
                     "type": "string",
                     "description": "The image pull policy",
                     "default": "Always"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "An optional list of references to secrets in the same namespace to use for pulling the main OpenFGA image. If specified, these secrets will be passed to individual puller implementations for them to use. For more information see https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod."
                 }
             },
             "additionalProperties": false
@@ -85,10 +108,6 @@
             "type": "object",
             "description": "Defines the pod security context for the OpenFGA pods. For more information see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod.",
             "default": {}
-        },
-        "imagePullSecrets": {
-            "type": "array",
-            "description": "An optional list of references to secrets in the same namespace to use for pulling any of the images used by the pod spec. If specified, these secrets will be passed to individual puller implementations for them to use. For more information see https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod."
         },
         "nodeSelector": {
             "type": "object",
@@ -1108,6 +1127,10 @@
             "type": "object",
             "description": "",
             "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "The container image registry to pull the initContainer from. It is prepended to the initContainer image repository. For example, if initContainer.registry is set to 'ghcr.io' and initContainer.repository is set to 'groundnuty/k8s-wait-for', the final image repository will be 'ghcr.io/groundnuty/k8s-wait-for'."
+                },
                 "repository": {
                     "type": "string",
                     "description": "The container image repository to pull the initContainer from",
@@ -1118,10 +1141,18 @@
                     "description": "The specific initContainer image tag to pull",
                     "default": "v1.6"
                 },
+                "digest": {
+                    "type": "string",
+                    "description": "The specific initContainer image digest to pull. Takes precedence over tag."
+                },
                 "pullPolicy": {
                     "type": "string",
                     "description": "The image pull policy to apply to the initContainer",
                     "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "An optional list of references to secrets in the same namespace to use for pulling the initContainer image. If specified, these secrets will be passed to individual puller implementations for them to use. For more information see https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod."
                 }
             }
         },

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -1,11 +1,17 @@
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
 replicaCount: 3
 
 image:
+  registry: ""
   repository: openfga/openfga
   pullPolicy: Always
   tag: ""
+  digest: ""
+  pullSecrets: []
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -49,9 +55,12 @@ securityContext:
   # runAsUser: 1000
 
 initContainer:
+  registry: ""
   repository: groundnuty/k8s-wait-for
   tag: "v2.0"
+  digest: ""
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 ## Configure extra options for OpenFGA containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
The Helm chart lacked support for global image registry and pull secrets configuration. Users couldn't:
- Override the container registry globally for all images (main OpenFGA + init containers)
- Set pull secrets at a global level or per-image level
- Easily switch between different registries (e.g., Docker Hub, GHCR, private registries)

This made it difficult for organizations with private registries or specific image pull requirements to deploy OpenFGA without maintaining custom forks.

#### How is it being solved?
The solution leverages the Bitnami common chart library (upgraded from 2.13.3 to 2.31.4) which provides standardized helper functions for:
1. Image rendering: common.images.image helper constructs full image paths with registry/repository/tag/digest
2. Pull secrets management: common.images.renderPullSecrets helper consolidates pull secrets from global and component-specific configurations

This follows Kubernetes and Helm best practices by supporting a hierarchy:
- Global settings (global.imageRegistry, global.imagePullSecrets)
- Component-specific settings (image.registry, image.pullSecrets)
- Component settings override global settings

#### What changes are made to solve it?
charts/openfga/values.yaml:53-62
- Added global.imageRegistry and global.imagePullSecrets fields
- Added image.registry, image.digest, and image.pullSecrets fields
- Added initContainer.registry, initContainer.digest, and initContainer.pullSecrets fields
- Removed top-level imagePullSecrets (migrated to component-specific)

charts/openfga/templates/_helpers.tpl:144-162
- Created openfga.pullSecrets helper (global and both main + init container images)
- Created openfga.jobPullSecrets helper (global and main image only - least privilege)
- Created openfga.image helper (renders full OpenFGA image path)
- Created openfga.initContainer.image helper (renders full init container image path)

charts/openfga/templates/*.yaml
- Replaced hardcoded image strings with helper templates
- Replaced manual imagePullSecrets YAML blocks with helper template calls

charts/openfga/values.schema.json
- Added comprehensive JSON schema documentation for all new fields

charts/openfga/Chart.yaml
- Upgraded Bitnami common chart dependency from 2.13.3 to 2.31.4

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added global settings for imageRegistry and imagePullSecrets.
  * Added registry, digest, and pullSecrets options for main and init container images; digest now supported and takes precedence over tag; init container pullPolicy configurable.
  * Unified handling of image references and imagePullSecrets across workloads for consistent configuration.

* Chores
  * Updated bundled common chart dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->