### PR TITLE
fix: replace use of undocumented `.Capabilities.KubeVersion.GitVersion`

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   {{- if not  .Values.autoscaling.enabled }}
-  replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory")}}
+  replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory") }}
   {{- end }}
   selector:
     matchLabels:
@@ -325,7 +325,7 @@ spec:
             {{- if .Values.requestTimeout }}
             - name: OPENFGA_REQUEST_TIMEOUT
               value: "{{ .Values.requestTimeout }}"
-            {{- end}}
+            {{- end }}
 
             {{- if .Values.checkQueryCache.enabled }}
             - name: OPENFGA_CHECK_QUERY_CACHE_ENABLED
@@ -462,7 +462,7 @@ spec:
           {{- with .Values.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}
-          {{- end}}
+          {{- end }}
 
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}

--- a/charts/openfga/templates/ingress.yaml
+++ b/charts/openfga/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/openfga/templates/ingress.yaml
+++ b/charts/openfga/templates/ingress.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "openfga.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.Version)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -23,7 +23,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.Version) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,11 +43,11 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "openfga.labels" . | nindent 4 }}
   {{- with .Values.migrate.labels }}
-    {{- toYaml . | nindent 4}}
-  {{- end}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.migrate.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -22,8 +22,8 @@ spec:
       labels:
         {{- include "openfga.labels" . | nindent 8 }}
       {{- with .Values.migrate.labels }}
-        {{- toYaml . | nindent 8}}
-      {{- end}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

#### What problem is being solved?
`.Capabilities.KubeVersion.GitVersion` is unsupported/undocumented by Helm.

#### How is it being solved?
Use `.Capabilities.KubeVersion.Version` instead

#### What changes are made to solve it?
Updating the charts.

This PR also fixes trivial stylistic issues for coherence, in a separate commit. Feel free to ignore.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

* [Supported values](https://helm.sh/docs/chart_template_guide/builtin_objects/)
* https://github.com/helm/helm/issues/12072

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
  - n/a
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
  - No test harness for Helm chart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied minor formatting-only adjustments to Helm chart templates for improved consistency.
* **Bug Fixes**
  * Improved Kubernetes version compatibility for Ingress rendering, including correct selection of Ingress API version, ingress class handling, and related rule/back-end fields based on the target cluster version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->