### PR TITLE
fix(otel): OPENFGA_TRACE_OTLP_TLS_ENABLED boolean flag quote

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -382,7 +382,7 @@ spec:
 
             {{- if .Values.telemetry.trace.otlp.tls.enabled }}
             - name: OPENFGA_TRACE_OTLP_TLS_ENABLED
-              value: {{ .Values.telemetry.trace.otlp.tls.enabled }}
+              value: "{{ .Values.telemetry.trace.otlp.tls.enabled }}"
             {{- end }}
 
             {{- if .Values.telemetry.trace.sampleRatio }}


### PR DESCRIPTION
This PR ensures that the `OPENFGA_TRACE_OTLP_TLS_ENABLED` environment variable is correctly handled as a boolean string within the Helm chart templates.

## Description

#### What problem is being solved?
Updates the OpenFGA Helm chart deployment template so OPENFGA_TRACE_OTLP_TLS_ENABLED is rendered as a Kubernetes-compatible string value when enabled, avoiding boolean-type env var rendering.

#### How is it being solved?

The issue is resolved by updating the deployment template to ensure that the value of `OPENFGA_TRACE_OTLP_TLS_ENABLED` is explicitly converted to a string (quoted) before being injected into the container environment. This ensures compatibility with Kubernetes API expectations and OpenFGA's configuration logic.

#### What changes are made to solve it?

Quote the rendered value for `OPENFGA_TRACE_OTLP_TLS_ENABLED` in deployment.yaml so it becomes "true" instead of true.
Keep the env var conditional on .Values.telemetry.trace.otlp.tls.enabled.

In the current Helm chart, the `OPENFGA_TRACE_OTLP_TLS_ENABLED` variable—used to toggle TLS for OpenTelemetry Protocol (OTLP) tracing—was not being correctly processed. In Kubernetes manifests, environment variable values must be strings. If a boolean (`true`/`false`) is passed directly from Helm's `values.yaml` without explicit casting or quoting, it causes template rendering errors or be misinterpreted by the OpenFGA server at runtime. 

## References

* closes [https://github.com/openfga/helm-charts/pull/279](https://github.com/openfga/helm-charts/pull/279)

## Review Checklist

* [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] ~~I have added documentation for new/changed functionality in this PR or in a PR to [[openfga.dev](https://github.com/openfga/openfga.dev)](https://github.com/openfga/openfga.dev)~~
* [x] The correct base branch is being used, if not `main`
* [ ] ~~I have added tests to validate that the change in functionality is working as expected~~ No test coverage

---

**Next Step:** Would you like me to help you draft a specific comment for the maintainers or analyze the related CI/CD failures if there are any?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration formatting for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->