### PR TITLE
fix: Add TTL cleanup for OpenFGA migration jobs to resolve HPA metric failures

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.51
+version: 0.2.52
 appVersion: "v1.11.2"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.migrate.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrate.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.migrate.annotations }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -194,66 +194,66 @@
                             "description": "enable/disable prometheus metrics on the '/metrics' endpoint",
                             "default": true
                         },
-			"serviceMonitor": {
-		            "type": "object",
-			    "properties": {
-			        "enabled": {
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
                                     "type": "boolean",
                                     "description": "enable/disable installation of serviceMonitor custom resource",
                                     "default": false
-			        },
-			        "additionalLabels": {
-			            "type": "object",
-			            "description": "additional labels to be added to the serivceMonitor resource",
-			            "default": {}
-			        },
-			        "annotations": {
-		                    "type": "object",
-			            "description": "annotations to be added to the serviceMonitor resource",
-			            "default": {}
-			        },
-			        "jobLabel": {
-			            "type": "string",
-			            "description": "the label to use to retrieve the job name from",
-			            "default": "app.kubernetes.io/name"
-			        },
-			        "namespace": {
-		                    "type": "string",
-			            "description": "namespace where the serviceMonitor resource should be installed to",
-			            "default": ""
-			        },
-			        "namespaceSelector": {
-			            "type": "object",
-			            "description": "which namespaces should be scraped",
-			            "default": {}
-			        },
-			        "scrapeInterval": {
-			            "type": "string",
-			            "description": "prometheus scrape interval",
-			            "default": "30s"
-			        },
-			        "scrapeTimeout": {
-			            "type": "string",
-			            "description": "prometheus scrape timeout",
-			            "default": "10s"
-			        },
-			        "targetLabels": {
-			            "type": "array",
-			            "description": "additional target labels to scrape",
-			            "default": []
-			        },
-			        "relabelings": {
-			            "type": "array",
-			            "description": "add job relabelings",
-			            "default": []
-			        },
-			        "metricRelabelings": {
-			            "type": "array",
-			            "description": "add metric relabelings",
-			            "default": []
-			        }
-			    }
-			},
+                                },
+                                "additionalLabels": {
+                                    "type": "object",
+                                    "description": "additional labels to be added to the serivceMonitor resource",
+                                    "default": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "annotations to be added to the serviceMonitor resource",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "the label to use to retrieve the job name from",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "namespace where the serviceMonitor resource should be installed to",
+                                    "default": ""
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "which namespaces should be scraped",
+                                    "default": {}
+                                },
+                                "scrapeInterval": {
+                                    "type": "string",
+                                    "description": "prometheus scrape interval",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "prometheus scrape timeout",
+                                    "default": "10s"
+                                },
+                                "targetLabels": {
+                                    "type": "array",
+                                    "description": "additional target labels to scrape",
+                                    "default": []
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "add job relabelings",
+                                    "default": []
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "add metric relabelings",
+                                    "default": []
+                                }
+                            }
+                        },
                         "addr": {
                             "type": "string",
                             "description": "the host:port address to serve the prometheus metrics server on",
@@ -709,10 +709,20 @@
             "type": "array",
             "description": "a list of experimental features to enable",
             "default": [],
-            "examples": ["enable-check-optimizations","enable-access-control", "enable-list-objects-optimizations", "pipeline_list_objects"],
+            "examples": [
+                "enable-check-optimizations",
+                "enable-access-control",
+                "enable-list-objects-optimizations",
+                "pipeline_list_objects"
+            ],
             "items": {
                 "type": "string",
-                "enum": ["enable-check-optimizations","enable-access-control", "enable-list-objects-optimizations", "pipeline_list_objects"]
+                "enum": [
+                    "enable-check-optimizations",
+                    "enable-access-control",
+                    "enable-list-objects-optimizations",
+                    "pipeline_list_objects"
+                ]
             }
         },
         "maxTuplesPerWrite": {
@@ -837,17 +847,17 @@
             "description": "the maximum results to return in ListUsers responses"
         },
         "requestTimeout": {
-          "type": [
-              "string",
-              "null"
-          ],
-          "description": "The timeout duration for a request.",
-          "format": "duration",
-          "examples": [
-              "3s",
-              "1m",
-              "200ms"
-          ]
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The timeout duration for a request.",
+            "format": "duration",
+            "examples": [
+                "3s",
+                "1m",
+                "200ms"
+            ]
         },
         "requestDurationDatastoreQueryCountBuckets": {
             "description": "datastore query count buckets used to label the histogram metric for measuring request duration.",
@@ -1093,6 +1103,14 @@
                     "description": "A timeout for the time it takes the migrate process to connect to the database",
                     "format": "duration",
                     "default": "1m"
+                },
+                "ttlSecondsAfterFinished": {
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "description": "Automatically delete migration Job pods after completion (in seconds). Prevents completed pods from interfering with HPA metric calculations.",
+                    "default": 300
                 }
             }
         },

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -194,66 +194,66 @@
                             "description": "enable/disable prometheus metrics on the '/metrics' endpoint",
                             "default": true
                         },
-                        "serviceMonitor": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
+			"serviceMonitor": {
+		            "type": "object",
+			    "properties": {
+			        "enabled": {
                                     "type": "boolean",
                                     "description": "enable/disable installation of serviceMonitor custom resource",
                                     "default": false
-                                },
-                                "additionalLabels": {
-                                    "type": "object",
-                                    "description": "additional labels to be added to the serivceMonitor resource",
-                                    "default": {}
-                                },
-                                "annotations": {
-                                    "type": "object",
-                                    "description": "annotations to be added to the serviceMonitor resource",
-                                    "default": {}
-                                },
-                                "jobLabel": {
-                                    "type": "string",
-                                    "description": "the label to use to retrieve the job name from",
-                                    "default": "app.kubernetes.io/name"
-                                },
-                                "namespace": {
-                                    "type": "string",
-                                    "description": "namespace where the serviceMonitor resource should be installed to",
-                                    "default": ""
-                                },
-                                "namespaceSelector": {
-                                    "type": "object",
-                                    "description": "which namespaces should be scraped",
-                                    "default": {}
-                                },
-                                "scrapeInterval": {
-                                    "type": "string",
-                                    "description": "prometheus scrape interval",
-                                    "default": "30s"
-                                },
-                                "scrapeTimeout": {
-                                    "type": "string",
-                                    "description": "prometheus scrape timeout",
-                                    "default": "10s"
-                                },
-                                "targetLabels": {
-                                    "type": "array",
-                                    "description": "additional target labels to scrape",
-                                    "default": []
-                                },
-                                "relabelings": {
-                                    "type": "array",
-                                    "description": "add job relabelings",
-                                    "default": []
-                                },
-                                "metricRelabelings": {
-                                    "type": "array",
-                                    "description": "add metric relabelings",
-                                    "default": []
-                                }
-                            }
-                        },
+			        },
+			        "additionalLabels": {
+			            "type": "object",
+			            "description": "additional labels to be added to the serivceMonitor resource",
+			            "default": {}
+			        },
+			        "annotations": {
+		                    "type": "object",
+			            "description": "annotations to be added to the serviceMonitor resource",
+			            "default": {}
+			        },
+			        "jobLabel": {
+			            "type": "string",
+			            "description": "the label to use to retrieve the job name from",
+			            "default": "app.kubernetes.io/name"
+			        },
+			        "namespace": {
+		                    "type": "string",
+			            "description": "namespace where the serviceMonitor resource should be installed to",
+			            "default": ""
+			        },
+			        "namespaceSelector": {
+			            "type": "object",
+			            "description": "which namespaces should be scraped",
+			            "default": {}
+			        },
+			        "scrapeInterval": {
+			            "type": "string",
+			            "description": "prometheus scrape interval",
+			            "default": "30s"
+			        },
+			        "scrapeTimeout": {
+			            "type": "string",
+			            "description": "prometheus scrape timeout",
+			            "default": "10s"
+			        },
+			        "targetLabels": {
+			            "type": "array",
+			            "description": "additional target labels to scrape",
+			            "default": []
+			        },
+			        "relabelings": {
+			            "type": "array",
+			            "description": "add job relabelings",
+			            "default": []
+			        },
+			        "metricRelabelings": {
+			            "type": "array",
+			            "description": "add metric relabelings",
+			            "default": []
+			        }
+			    }
+			},
                         "addr": {
                             "type": "string",
                             "description": "the host:port address to serve the prometheus metrics server on",
@@ -709,20 +709,10 @@
             "type": "array",
             "description": "a list of experimental features to enable",
             "default": [],
-            "examples": [
-                "enable-check-optimizations",
-                "enable-access-control",
-                "enable-list-objects-optimizations",
-                "pipeline_list_objects"
-            ],
+            "examples": ["enable-check-optimizations","enable-access-control", "enable-list-objects-optimizations", "pipeline_list_objects"],
             "items": {
                 "type": "string",
-                "enum": [
-                    "enable-check-optimizations",
-                    "enable-access-control",
-                    "enable-list-objects-optimizations",
-                    "pipeline_list_objects"
-                ]
+                "enum": ["enable-check-optimizations","enable-access-control", "enable-list-objects-optimizations", "pipeline_list_objects"]
             }
         },
         "maxTuplesPerWrite": {
@@ -847,17 +837,17 @@
             "description": "the maximum results to return in ListUsers responses"
         },
         "requestTimeout": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "The timeout duration for a request.",
-            "format": "duration",
-            "examples": [
-                "3s",
-                "1m",
-                "200ms"
-            ]
+          "type": [
+              "string",
+              "null"
+          ],
+          "description": "The timeout duration for a request.",
+          "format": "duration",
+          "examples": [
+              "3s",
+              "1m",
+              "200ms"
+          ]
         },
         "requestDurationDatastoreQueryCountBuckets": {
             "description": "datastore query count buckets used to label the histogram metric for measuring request duration.",

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -35,12 +35,10 @@ extraVolumes: []
 extraVolumeMounts: []
 extraInitContainers: []
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -301,8 +299,7 @@ allowEvaluating1_0Models:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -356,6 +353,9 @@ migrate:
     helm.sh/hook-delete-policy: "before-hook-creation"
   labels: {}
   timeout:
+  # Automatically delete migration Job pods after completion (in seconds).
+  # Prevents completed pods from interfering with HPA metric calculations.
+  ttlSecondsAfterFinished:
 
 testPodSpec: {}
 testContainerSpec: {}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
When running OpenFGA with Horizontal Pod Autoscaler (HPA) in Kubernetes, completed migration Job pods can cause HPA metric collection failures. Since migration pods lack resource requests, the HPA reports FailedGetResourceMetric errors and shows <unknown> for CPU and memory utilization, preventing proper autoscaling.

#### How is it being solved?
By adding a configurable ttlSecondsAfterFinished option to the migration Job spec. This leverages Kubernetes' built-in TTL controller to automatically clean up completed Job pods after a specified duration.

#### What changes are made to solve it?

- Added ttlSecondsAfterFinished field to the migration Job template
- Added corresponding value in values.yaml with a default of 300 seconds (5 minutes)
- Included inline documentation explaining the purpose of the configuration

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->
N/A

## Review Checklist
- [ x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 0.2.52

* **New Features**
  * Added automatic Job cleanup configuration for migration jobs. Migration Job pods can now be automatically deleted after completion with a configurable duration (in seconds). The default cleanup duration is set to 300 seconds but can be customized through your Helm values configuration to meet your specific operational requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->