### PR TITLE
feat(chart): enable template rendering in extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
           {{- with .Values.migrate.extraVolumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.migrate.sidecars }}
           {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
@@ -456,7 +456,7 @@ spec:
 
           {{- with .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 12 }}
           {{- end }}
 
           {{- with .Values.lifecycle }}
@@ -470,7 +470,7 @@ spec:
 
       {{- with .Values.extraVolumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openfga/templates/job.yaml
+++ b/charts/openfga/templates/job.yaml
@@ -56,7 +56,7 @@ spec:
             {{- toYaml .Values.datastore.migrations.resources | nindent 12 }}
           {{- with .Values.migrate.extraVolumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.migrate.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.migrate.sidecars "context" $) | nindent 8 }}
@@ -64,7 +64,7 @@ spec:
       restartPolicy: Never
       {{- with .Values.migrate.extraVolumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary

This PR enables Helm template rendering in `extraVolumes` and `extraVolumeMounts` fields by replacing `toYaml` with `common.tplvalues.render`. This allows users to reference dynamic values like `{{ .Release.Namespace }}` or `{{ .Release.Name }}` in volume configurations.

## Changes

- **deployment.yaml**: Updated `extraVolumes`, `extraVolumeMounts`, and `migrate.extraVolumeMounts` to use `common.tplvalues.render`
- **job.yaml**: Updated `migrate.extraVolumes` and `migrate.extraVolumeMounts` to use `common.tplvalues.render`

## Motivation

This change maintains consistency with other template fields in the chart that already use `common.tplvalues.render` (e.g., `sidecars`, probes). It provides users with more flexibility when configuring volumes, especially in multi-tenant or multi-namespace scenarios.

## Example Usage

After this change, users can now use templates in their values:

\`\`\`yaml
extraVolumes:
  - name: my-config
    configMap:
      name: my-config-{{ .Release.Namespace }}

extraVolumeMounts:
  - name: my-config
    mountPath: /etc/config/{{ .Release.Name }}
\`\`\`

## Testing

- [x] Changes follow Conventional Commits specification
- [x] Updated both deployment and migration job templates
- [x] Maintains backward compatibility (existing static values work unchanged)
- [x] Uses existing `common.tplvalues.render` helper from Bitnami common chart dependency

The change is non-breaking as static values will continue to work as before, while now also supporting template evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated template rendering logic to use a generic renderer helper for improved maintainability. Functional behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->