### PR TITLE
fix: migrate bitnami sub-chart dependencies to legacy archive repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Add Helm Repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami-legacy https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add openfga https://openfga.github.io/helm-charts
           helm repo update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Add Helm Repositories
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami-legacy https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add openfga https://openfga.github.io/helm-charts
           helm repo update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run helm unit tests
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami-legacy https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm dependency build charts/openfga
           helm unittest charts/openfga
 

--- a/charts/openfga/Chart.lock
+++ b/charts/openfga/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 12.12.10
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 9.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.13.3
-digest: sha256:a152c0abc09cadc6a2158e237b67485b3177d1ed8ad9b7f0b64af300b4eb6e25
-generated: "2025-03-27T13:49:29.005097735+01:00"
+digest: sha256:4bbfb25821b0dfb6c70aabb5caf4c5ec7e6526261f93a8f531f507f1d4c43e3e
+generated: "2026-03-18T11:41:40.1785546-04:00"

--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.2.61
+version: 0.2.62
 appVersion: "v1.13.1"
 
 home: "https://openfga.github.io/helm-charts"
@@ -16,13 +16,17 @@ annotations:
     url: https://openfga.github.io/helm-charts/pgp-public-key.asc
 
 dependencies:
+  # DEPRECATED: These database sub-charts use the Bitnami legacy archive repo which
+  # is no longer actively maintained or receiving security updates.
+  # They are provided for backwards compatibility only.
+  # For new deployments, use extraObjects with official Docker images (see values.yaml).
   - name: postgresql
     version: "12.12.10"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: mysql
     version: "9.6.0"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: mysql.enabled
   - name: common
     version: "2.13.3"

--- a/charts/openfga/README.md
+++ b/charts/openfga/README.md
@@ -31,6 +31,12 @@ To pull from the GitHub OCI registry, run:
 helm install openfga -f values.yaml oci://ghcr.io/openfga/helm-charts
 ```
 
+## Deprecation Notice
+
+> **The bundled Bitnami PostgreSQL and MySQL sub-charts (`postgresql.enabled` / `mysql.enabled`) are deprecated and will be removed in a future release.** These sub-charts rely on the [Bitnami legacy archive repository](https://github.com/bitnami/charts/tree/archive-full-index), which is no longer actively maintained or receiving security updates.
+>
+> Use the `extraObjects` pattern with official Docker images instead. See the [Postgres dev/test setup](#devtest-only-quick-postgres-setup) and [MySQL dev/test setup](#devtest-only-quick-mysql-setup) sections below for working examples.
+
 ## Customization
 
 If you wish to customize the OpenFGA deployment you may supply paremeters such as the ones listed in the [values.yaml](/charts/openfga/values.yaml).
@@ -52,42 +58,42 @@ commonLabels:
 
 ### Installing with Postgres
 
-If you do not already have a Postgres deployment, you can deploy OpenFGA with Postgres with the following command:
+If you have an existing Postgres deployment, connect OpenFGA to it by providing the `datastore.uri` parameter:
 
 ```sh
 helm install openfga openfga/openfga \
   --set datastore.engine=postgres \
-  --set datastore.uri="postgres://postgres:password@openfga-postgresql.default.svc.cluster.local:5432/postgres?sslmode=disable" \
-  --set postgresql.enabled=true \
-  --set postgresql.auth.postgresPassword=password \
-  --set postgresql.auth.database=postgres
+  --set datastore.uri="postgres://postgres:password@postgres.default.svc.cluster.local:5432/openfga?sslmode=disable"
 ```
 
-This will bootstrap a Postgres deployment using the [`bitnami/postgresql`](https://artifacthub.io/packages/helm/bitnami/postgresql) chart and deploy OpenFGA configured in a way to connect to it.
+#### Dev/Test Only: Quick Postgres Setup
+
+If you do not have an existing Postgres deployment and just need a quick dev/test environment, you can use `extraObjects` to deploy a minimal Postgres instance alongside OpenFGA. **This is not suitable for production** — use a managed database service or an operator like [CloudNativePG](https://cloudnative-pg.io/) instead.
+
+See [ci/postgres-values.yaml](/charts/openfga/ci/postgres-values.yaml) for a complete working example. To use it:
+
+```sh
+helm install openfga openfga/openfga -f postgres-values.yaml
+```
 
 ### Installing with MySQL
 
-If you do not already have a MySQL deployment, you can deploy OpenFGA with MySQL with the following command:
+If you have an existing MySQL deployment, connect OpenFGA to it by providing the `datastore.uri` parameter:
 
 ```sh
 helm install openfga openfga/openfga \
   --set datastore.engine=mysql \
-  --set datastore.uri="root:password@tcp(openfga-mysql.default.svc.cluster.local:3306)/mysql?parseTime=true" \
-  --set mysql.enabled=true \
-  --set mysql.auth.rootPassword=password \
-  --set mysql.auth.database=mysql
+  --set datastore.uri="root:password@tcp(mysql.default.svc.cluster.local:3306)/openfga?parseTime=true"
 ```
 
-This will bootstrap a MySQL deployment using the [`bitnami/mysql`](https://artifacthub.io/packages/helm/bitnami/mysql) chart and deploy OpenFGA configured in a way to connect to it.
+#### Dev/Test Only: Quick MySQL Setup
 
-### Connecting to an existing Postgres or MySQL deployment
+If you do not have an existing MySQL deployment and just need a quick dev/test environment, you can use `extraObjects` to deploy a minimal MySQL instance alongside OpenFGA. **This is not suitable for production** — use a managed database service or a MySQL operator instead.
 
-If you have an existing Postgres or MySQL deployment, you can connect OpenFGA to it by providing the `datastore.uri` parameter. For example, to connect to a Postgres deployment:
+See [ci/mysql-values.yaml](/charts/openfga/ci/mysql-values.yaml) for a complete working example. To use it:
 
 ```sh
-helm install openfga openfga/openfga \
-  --set datastore.engine=postgres \
-  --set datastore.uri="postgres://postgres:password@postgres.postgres:5432/postgres?sslmode=disable"
+helm install openfga openfga/openfga -f mysql-values.yaml
 ```
 
 ### Using an existing secret for Postgres or MySQL
@@ -131,6 +137,17 @@ To uninstall/delete the `openfga` deployment:
 ```sh
 helm uninstall openfga
 ```
+
+## Development
+
+If you are developing or building the chart locally and still using the deprecated Bitnami sub-chart dependencies (`postgresql.enabled` / `mysql.enabled`), you need to add the Bitnami legacy archive repository before running `helm dep update`:
+
+```sh
+helm repo add bitnami-legacy https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+helm dep update charts/openfga
+```
+
+This is not required if you are using the recommended `extraObjects` pattern.
 
 ## Chart Parameters
 

--- a/charts/openfga/README.md
+++ b/charts/openfga/README.md
@@ -37,6 +37,27 @@ helm install openfga -f values.yaml oci://ghcr.io/openfga/helm-charts
 >
 > Use the `extraObjects` pattern with official Docker images instead. See the [Postgres dev/test setup](#devtest-only-quick-postgres-setup) and [MySQL dev/test setup](#devtest-only-quick-mysql-setup) sections below for working examples.
 
+## Migrating Off Bundled Database Sub-Charts
+
+The bundled Bitnami PostgreSQL and MySQL sub-charts (`postgresql.enabled` / `mysql.enabled`) are deprecated and will be removed after July 2026. Migrate to a standalone database to continue receiving security updates.
+
+### Database Version Compatibility
+
+The bundled sub-charts ship with:
+- **PostgreSQL 15.4** (`bitnamilegacy/postgresql:15.4.0-debian-11-r45`)
+- **MySQL 8.0** (`bitnamilegacy/mysql:8.0.32-debian-11-r14`)
+
+When migrating, use a database version that is **equal to or newer** than the version above. OpenFGA supports PostgreSQL 14+ and MySQL 8.0+.
+
+### Migration Guides
+
+Step-by-step guides with complete values files, Bitnami compatibility notes, and verified migration paths:
+
+- **[Migrate PostgreSQL from Bitnami to Official Docker Image](docs/migrate-postgres-from-bitnami.md)** — covers the init container needed for Bitnami's non-standard config file layout
+- **[Migrate MySQL from Bitnami to Official Docker Image](docs/migrate-mysql-from-bitnami.md)** — covers the `--datadir` flag needed for Bitnami's non-standard data directory
+
+Both guides follow the same pattern: protect the PV, disable the sub-chart, deploy the official image via `extraObjects` reusing the existing PVC, and verify data integrity — all in a single `helm upgrade`.
+
 ## Customization
 
 If you wish to customize the OpenFGA deployment you may supply paremeters such as the ones listed in the [values.yaml](/charts/openfga/values.yaml).

--- a/charts/openfga/ci/mysql-values.yaml
+++ b/charts/openfga/ci/mysql-values.yaml
@@ -1,0 +1,54 @@
+datastore:
+  engine: mysql
+  uriSecret: openfga-mysql-credentials
+  migrationType: initContainer
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openfga-mysql-credentials
+    stringData:
+      MYSQL_ROOT_PASSWORD: changeme
+      MYSQL_USER: openfga
+      MYSQL_PASSWORD: changeme
+      MYSQL_DATABASE: openfga
+      uri: "openfga:changeme@tcp(openfga-mysql:3306)/openfga?parseTime=true"
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: openfga-mysql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: openfga-mysql
+      template:
+        metadata:
+          labels:
+            app: openfga-mysql
+        spec:
+          containers:
+            - name: mysql
+              image: mysql:8.4
+              ports:
+                - containerPort: 3306
+              envFrom:
+                - secretRef:
+                    name: openfga-mysql-credentials
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/mysql
+          volumes:
+            - name: data
+              emptyDir: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: openfga-mysql
+    spec:
+      selector:
+        app: openfga-mysql
+      ports:
+        - port: 3306
+          targetPort: 3306

--- a/charts/openfga/ci/postgres-values.yaml
+++ b/charts/openfga/ci/postgres-values.yaml
@@ -1,0 +1,53 @@
+datastore:
+  engine: postgres
+  uriSecret: openfga-postgres-credentials
+  migrationType: initContainer
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openfga-postgres-credentials
+    stringData:
+      POSTGRES_USER: openfga
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: openfga
+      uri: "postgres://openfga:changeme@openfga-postgres:5432/openfga?sslmode=disable"
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: openfga-postgres
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: openfga-postgres
+      template:
+        metadata:
+          labels:
+            app: openfga-postgres
+        spec:
+          containers:
+            - name: postgres
+              image: postgres:17
+              ports:
+                - containerPort: 5432
+              envFrom:
+                - secretRef:
+                    name: openfga-postgres-credentials
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql/data
+          volumes:
+            - name: data
+              emptyDir: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: openfga-postgres
+    spec:
+      selector:
+        app: openfga-postgres
+      ports:
+        - port: 5432
+          targetPort: 5432

--- a/charts/openfga/docs/migrate-mysql-from-bitnami.md
+++ b/charts/openfga/docs/migrate-mysql-from-bitnami.md
@@ -1,0 +1,176 @@
+# Migrating MySQL from Bitnami Sub-Chart to Official Docker Image
+
+This guide walks through migrating from the deprecated bundled Bitnami MySQL sub-chart (`mysql.enabled: true`) to a standalone MySQL instance using official Docker images and the `extraObjects` pattern. All existing data (stores, authorization models, relationship tuples) is preserved.
+
+> **Production deployments** should migrate to a managed database service (e.g., Amazon RDS, Cloud SQL, Azure Database for MySQL) or a MySQL operator. The `extraObjects` approach shown here is suitable for dev/test environments.
+
+## Prerequisites
+
+- Helm 3.x
+- `kubectl` access to the cluster
+- An existing OpenFGA release using `mysql.enabled: true`
+
+## Overview
+
+| Step | Action |
+|------|--------|
+| 1 | Protect the existing data volume |
+| 2 | Prepare the new values file |
+| 3 | Run `helm upgrade` |
+| 4 | Verify data integrity |
+
+## Step 1: Protect the Existing Data Volume
+
+The bundled Bitnami sub-chart creates a PersistentVolumeClaim (PVC) named `data-<release>-mysql-0`. When the sub-chart is disabled, Helm will remove the StatefulSet. To prevent the underlying PersistentVolume from being deleted, set its reclaim policy to `Retain`:
+
+```sh
+# Find the PVC
+kubectl get pvc -n <namespace> -l app.kubernetes.io/instance=<release-name>
+
+# Patch the PV reclaim policy
+PV_NAME=$(kubectl get pvc data-<release>-mysql-0 -n <namespace> -o jsonpath='{.spec.volumeName}')
+kubectl patch pv "${PV_NAME}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+Confirm the policy change:
+```sh
+kubectl get pv "${PV_NAME}" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}'
+# Should output: Retain
+```
+
+## Step 2: Prepare the New Values File
+
+Create a new values file that disables the Bitnami sub-chart and deploys MySQL via `extraObjects`.
+
+### Bitnami Data Directory Compatibility
+
+The Bitnami MySQL image stores data at `/bitnami/mysql/data`. The official `mysql` Docker image defaults to `/var/lib/mysql`.
+
+**Solution:** Mount the existing PVC at `/bitnami/mysql` and pass `--datadir=/bitnami/mysql/data` to the MySQL container so it finds the existing data files in place. Unlike PostgreSQL, no init container is needed — MySQL auto-detects an existing data directory.
+
+### Values File
+
+```yaml
+# Disable the bundled Bitnami sub-chart
+mysql:
+  enabled: false
+
+datastore:
+  engine: mysql
+  uriSecret: openfga-mysql-credentials
+  applyMigrations: true
+
+extraObjects:
+  # Connection secret for OpenFGA
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openfga-mysql-credentials
+    stringData:
+      uri: "<user>:<password>@tcp(openfga-mysql:3306)/<database>?parseTime=true"
+
+  # Standalone MySQL Deployment reusing the existing PVC
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: openfga-mysql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: openfga-mysql
+      template:
+        metadata:
+          labels:
+            app: openfga-mysql
+        spec:
+          containers:
+            - name: mysql
+              image: mysql:8.0
+              ports:
+                - containerPort: 3306
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  value: "<password>"
+                - name: MYSQL_DATABASE
+                  value: "<database>"
+              args:
+                - --datadir=/bitnami/mysql/data
+              volumeMounts:
+                - name: data
+                  mountPath: /bitnami/mysql
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: data-<release>-mysql-0
+
+  # Service so OpenFGA can connect
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: openfga-mysql
+    spec:
+      selector:
+        app: openfga-mysql
+      ports:
+        - port: 3306
+          targetPort: 3306
+```
+
+Replace `<release>`, `<user>`, `<password>`, and `<database>` with your actual values.
+
+### Key Details
+
+- **`mysql:8.0`** — matches the Bitnami sub-chart's MySQL 8.0.x. Using the same major version avoids data directory incompatibilities. You can upgrade to a newer version after the migration succeeds.
+- **`--datadir=/bitnami/mysql/data`** — tells the official image to use the same data directory path as Bitnami, so the existing data is found in place.
+- **No init container needed** — unlike PostgreSQL, MySQL auto-detects an existing data directory and does not require config file fixups.
+
+## Step 3: Run the Upgrade
+
+Delete the previous migration job (Helm cannot update completed Jobs) and upgrade:
+
+```sh
+kubectl delete job <release>-migrate -n <namespace> --ignore-not-found
+helm upgrade <release> openfga/openfga -n <namespace> -f values.yaml
+```
+
+After the upgrade:
+- The Bitnami `<release>-mysql-0` StatefulSet pod is removed
+- A new `openfga-mysql-*` Deployment pod starts using the same PVC
+- The OpenFGA migration job runs and completes
+- The OpenFGA app pod connects to the new MySQL instance
+
+## Step 4: Verify Data Integrity
+
+```sh
+# Check all pods are healthy
+kubectl get pods -n <namespace>
+
+# Confirm OpenFGA is serving
+kubectl exec -n <namespace> deploy/<release> -- wget -qO- http://localhost:8080/healthz
+# Expected: {"status":"SERVING"}
+
+# Verify your stores exist
+kubectl exec -n <namespace> deploy/<release> -- wget -qO- http://localhost:8080/stores
+
+# Spot-check a permission query
+curl -s -X POST http://<openfga-host>:8080/stores/<store-id>/check \
+  -H "Content-Type: application/json" \
+  -d '{"tuple_key":{"user":"user:anne","relation":"owner","object":"document:budget"},"authorization_model_id":"<model-id>"}'
+```
+
+## After Migration
+
+Once you have confirmed data integrity, you can optionally reset the PV reclaim policy back to `Delete`:
+
+```sh
+kubectl patch pv "${PV_NAME}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+```
+
+## Tested Migration Path
+
+This migration path has been validated end-to-end on a Kubernetes cluster:
+
+- **From:** Bitnami MySQL sub-chart (`mysql.enabled: true`, MySQL 8.0.32)
+- **To:** Official `mysql:8.0` Docker image via `extraObjects`
+- **Result:** All stores, authorization models, and relationship tuples preserved. All permission checks passed. Zero data loss, single `helm upgrade` command.

--- a/charts/openfga/docs/migrate-postgres-from-bitnami.md
+++ b/charts/openfga/docs/migrate-postgres-from-bitnami.md
@@ -1,0 +1,215 @@
+# Migrating PostgreSQL from Bitnami Sub-Chart to Official Docker Image
+
+This guide walks through migrating from the deprecated bundled Bitnami PostgreSQL sub-chart (`postgresql.enabled: true`) to a standalone PostgreSQL instance using official Docker images and the `extraObjects` pattern. All existing data (stores, authorization models, relationship tuples) is preserved.
+
+> **Production deployments** should migrate to a managed database service (e.g., Amazon RDS, Cloud SQL, Azure Database for PostgreSQL) or an operator like [CloudNativePG](https://cloudnative-pg.io/). The `extraObjects` approach shown here is suitable for dev/test environments.
+
+## Prerequisites
+
+- Helm 3.x
+- `kubectl` access to the cluster
+- An existing OpenFGA release using `postgresql.enabled: true`
+
+## Overview
+
+| Step | Action |
+|------|--------|
+| 1 | Protect the existing data volume |
+| 2 | Prepare the new values file |
+| 3 | Run `helm upgrade` |
+| 4 | Verify data integrity |
+
+## Step 1: Protect the Existing Data Volume
+
+The bundled Bitnami sub-chart creates a PersistentVolumeClaim (PVC) named `data-<release>-postgresql-0`. When the sub-chart is disabled, Helm will remove the StatefulSet. To prevent the underlying PersistentVolume from being deleted, set its reclaim policy to `Retain`:
+
+```sh
+# Find the PVC
+kubectl get pvc -n <namespace> -l app.kubernetes.io/instance=<release-name>
+
+# Patch the PV reclaim policy
+PV_NAME=$(kubectl get pvc data-<release>-postgresql-0 -n <namespace> -o jsonpath='{.spec.volumeName}')
+kubectl patch pv "${PV_NAME}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+Confirm the policy change:
+```sh
+kubectl get pv "${PV_NAME}" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}'
+# Should output: Retain
+```
+
+## Step 2: Prepare the New Values File
+
+Create a new values file that disables the Bitnami sub-chart and deploys PostgreSQL via `extraObjects`.
+
+### Bitnami Data Directory Compatibility
+
+The Bitnami PostgreSQL image stores data at `/bitnami/postgresql/data` and keeps `postgresql.conf` and `pg_hba.conf` outside the PGDATA directory. The official `postgres` Docker image expects these config files inside PGDATA.
+
+**Solution:** An init container creates the missing config files before the postgres container starts.
+
+### Values File
+
+```yaml
+# Disable the bundled Bitnami sub-chart
+postgresql:
+  enabled: false
+
+datastore:
+  engine: postgres
+  uriSecret: openfga-postgres-credentials
+  applyMigrations: true
+
+extraObjects:
+  # Connection secret for OpenFGA
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openfga-postgres-credentials
+    stringData:
+      uri: "postgres://<user>:<password>@openfga-postgres:5432/<database>?sslmode=disable"
+
+  # Standalone PostgreSQL Deployment reusing the existing PVC
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: openfga-postgres
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: openfga-postgres
+      template:
+        metadata:
+          labels:
+            app: openfga-postgres
+        spec:
+          initContainers:
+            - name: fix-bitnami-conf
+              image: busybox
+              command:
+                - sh
+                - -c
+                - |
+                  PGDATA=/data/data
+                  if [ ! -f "$PGDATA/postgresql.conf" ]; then
+                    cat > "$PGDATA/postgresql.conf" <<'CONF'
+                  listen_addresses = '*'
+                  max_connections = 100
+                  shared_buffers = 128MB
+                  dynamic_shared_memory_type = posix
+                  max_wal_size = 1GB
+                  min_wal_size = 80MB
+                  log_timezone = 'UTC'
+                  datestyle = 'iso, mdy'
+                  timezone = 'UTC'
+                  lc_messages = 'en_US.utf8'
+                  lc_monetary = 'en_US.utf8'
+                  lc_numeric = 'en_US.utf8'
+                  lc_time = 'en_US.utf8'
+                  default_text_search_config = 'pg_catalog.english'
+                  CONF
+                    echo "Created postgresql.conf"
+                  fi
+                  if [ ! -f "$PGDATA/pg_hba.conf" ]; then
+                    cat > "$PGDATA/pg_hba.conf" <<'HBA'
+                  local   all   all                 trust
+                  host    all   all   127.0.0.1/32  scram-sha-256
+                  host    all   all   ::1/128       scram-sha-256
+                  host    all   all   0.0.0.0/0     scram-sha-256
+                  HBA
+                    echo "Created pg_hba.conf"
+                  fi
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+          containers:
+            - name: postgres
+              image: postgres:15
+              ports:
+                - containerPort: 5432
+              env:
+                - name: POSTGRES_USER
+                  value: "<user>"
+                - name: POSTGRES_PASSWORD
+                  value: "<password>"
+                - name: PGDATA
+                  value: /bitnami/postgresql/data
+              volumeMounts:
+                - name: data
+                  mountPath: /bitnami/postgresql
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: data-<release>-postgresql-0
+
+  # Service so OpenFGA can connect
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: openfga-postgres
+    spec:
+      selector:
+        app: openfga-postgres
+      ports:
+        - port: 5432
+          targetPort: 5432
+```
+
+Replace `<release>`, `<user>`, `<password>`, and `<database>` with your actual values.
+
+### Key Details
+
+- **`postgres:15`** — matches the Bitnami sub-chart's PostgreSQL 15.4. Using the same major version avoids data directory incompatibilities. You can upgrade to a newer major version after the migration succeeds.
+- **`PGDATA=/bitnami/postgresql/data`** — tells the official image to use the same data directory path as Bitnami, so the existing data is found in place.
+- **Init container** — creates `postgresql.conf` and `pg_hba.conf` inside PGDATA, which Bitnami stores elsewhere. This only runs once (the `if` guard skips creation on subsequent restarts).
+
+## Step 3: Run the Upgrade
+
+Delete the previous migration job (Helm cannot update completed Jobs) and upgrade:
+
+```sh
+kubectl delete job <release>-migrate -n <namespace> --ignore-not-found
+helm upgrade <release> openfga/openfga -n <namespace> -f values.yaml
+```
+
+After the upgrade:
+- The Bitnami `<release>-postgresql-0` StatefulSet pod is removed
+- A new `openfga-postgres-*` Deployment pod starts using the same PVC
+- The OpenFGA migration job runs and completes
+- The OpenFGA app pod connects to the new PostgreSQL instance
+
+## Step 4: Verify Data Integrity
+
+```sh
+# Check all pods are healthy
+kubectl get pods -n <namespace>
+
+# Confirm OpenFGA is serving
+kubectl exec -n <namespace> deploy/<release> -- wget -qO- http://localhost:8080/healthz
+# Expected: {"status":"SERVING"}
+
+# Verify your stores exist
+kubectl exec -n <namespace> deploy/<release> -- wget -qO- http://localhost:8080/stores
+
+# Spot-check a permission query
+curl -s -X POST http://<openfga-host>:8080/stores/<store-id>/check \
+  -H "Content-Type: application/json" \
+  -d '{"tuple_key":{"user":"user:alice","relation":"viewer","object":"document:readme"},"authorization_model_id":"<model-id>"}'
+```
+
+## After Migration
+
+Once you have confirmed data integrity, you can optionally reset the PV reclaim policy back to `Delete`:
+
+```sh
+kubectl patch pv "${PV_NAME}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+```
+
+## Tested Migration Path
+
+This migration path has been validated end-to-end on a Kubernetes cluster:
+
+- **From:** Bitnami PostgreSQL sub-chart (`postgresql.enabled: true`, PostgreSQL 15.4)
+- **To:** Official `postgres:15` Docker image via `extraObjects`
+- **Result:** All stores, authorization models, and relationship tuples preserved. All permission checks passed. Zero data loss, single `helm upgrade` command.

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -504,20 +504,22 @@
         },
         "postgresql": {
             "type": "object",
+            "description": "DEPRECATED: The bundled Bitnami PostgreSQL sub-chart uses the legacy archive repository which is no longer actively maintained or receiving security updates. Provided for backwards compatibility only. Will be removed in a future release.",
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "enable the bitnami/postgresql subchart and deploy Postgres",
+                    "description": "DEPRECATED: enable the bitnami/postgresql subchart (uses unsupported legacy archive)",
                     "default": false
                 }
             }
         },
         "mysql": {
             "type": "object",
+            "description": "DEPRECATED: The bundled Bitnami MySQL sub-chart uses the legacy archive repository which is no longer actively maintained or receiving security updates. Provided for backwards compatibility only. Will be removed in a future release.",
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "enable the bitnami/mysql subchart and deploy MySQL",
+                    "description": "DEPRECATED: enable the bitnami/mysql subchart (uses unsupported legacy archive)",
                     "default": false
                 }
             }

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -233,13 +233,24 @@ datastore:
       pullPolicy: Always
       tag: "v2.0"
 
+## DEPRECATED: The bundled PostgreSQL and MySQL sub-charts use the Bitnami legacy
+## archive repository which is no longer actively maintained or receiving security updates.
+## They are provided for backwards compatibility only and will be removed in subsequent releases.
 postgresql:
-  ## @param postgresql.enabled enable the bitnami/postgresql subchart and deploy Postgres
+  ## @param postgresql.enabled enable the bitnami/postgresql subchart (DEPRECATED - uses unsupported legacy archive)
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 15.4.0-debian-11-r45
 
 mysql:
-  ## @param mysql.enabled enable the bitnami/mysql subchart and deploy MySQL
+  ## @param mysql.enabled enable the bitnami/mysql subchart (DEPRECATED - uses unsupported legacy archive)
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/mysql
+    tag: 8.0.32-debian-11-r14
 
 grpc:
   addr: 0.0.0.0:8081
@@ -374,12 +385,110 @@ testContainerSpec: {}
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates
 extraObjects: []
-## Example: Deploying a CloudnativePG Postgres cluster for use with OpenFGA:
-# - apiVersion: postgresql.cnpg.io/v1
-#   kind: Cluster
+## Example: Deploy a PostgreSQL instance for dev/test using official Docker images.
+## For production, use a managed database service or an operator like CloudnativePG.
+## Configure the chart to use the secret:
+##   datastore:
+##     engine: postgres
+##     uriSecret: openfga-postgres-credentials   # (PostgreSQL example)
+##     # or
+##     uriSecret: openfga-mysql-credentials      # (MySQL example)
+#
+## PostgreSQL dev/test example:
+# - apiVersion: v1
+#   kind: Secret
 #   metadata:
-#     name: openfga
+#     name: openfga-postgres-credentials
+#   stringData:
+#     POSTGRES_USER: openfga
+#     POSTGRES_PASSWORD: changeme
+#     POSTGRES_DB: openfga
+#     uri: "postgres://openfga:changeme@openfga-postgres:5432/openfga?sslmode=disable"
+# - apiVersion: apps/v1
+#   kind: Deployment
+#   metadata:
+#     name: openfga-postgres
 #   spec:
-#     instances: 3
-#     storage:
-#       size: 10Gi
+#     replicas: 1
+#     selector:
+#       matchLabels:
+#         app: openfga-postgres
+#     template:
+#       metadata:
+#         labels:
+#           app: openfga-postgres
+#       spec:
+#         containers:
+#           - name: postgres
+#             image: postgres:17
+#             ports:
+#               - containerPort: 5432
+#             envFrom:
+#               - secretRef:
+#                   name: openfga-postgres-credentials
+#             volumeMounts:
+#               - name: data
+#                 mountPath: /var/lib/postgresql/data
+#         volumes:
+#           - name: data
+#             emptyDir: {}
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#     name: openfga-postgres
+#   spec:
+#     selector:
+#       app: openfga-postgres
+#     ports:
+#       - port: 5432
+#         targetPort: 5432
+#
+## MySQL dev/test example:
+# - apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: openfga-mysql-credentials
+#   stringData:
+#     MYSQL_ROOT_PASSWORD: changeme
+#     MYSQL_USER: openfga
+#     MYSQL_PASSWORD: changeme
+#     MYSQL_DATABASE: openfga
+#     uri: "openfga:changeme@tcp(openfga-mysql:3306)/openfga?parseTime=true"
+# - apiVersion: apps/v1
+#   kind: Deployment
+#   metadata:
+#     name: openfga-mysql
+#   spec:
+#     replicas: 1
+#     selector:
+#       matchLabels:
+#         app: openfga-mysql
+#     template:
+#       metadata:
+#         labels:
+#           app: openfga-mysql
+#       spec:
+#         containers:
+#           - name: mysql
+#             image: mysql:8.4
+#             ports:
+#               - containerPort: 3306
+#             envFrom:
+#               - secretRef:
+#                   name: openfga-mysql-credentials
+#             volumeMounts:
+#               - name: data
+#                 mountPath: /var/lib/mysql
+#         volumes:
+#           - name: data
+#             emptyDir: {}
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#     name: openfga-mysql
+#   spec:
+#     selector:
+#       app: openfga-mysql
+#     ports:
+#       - port: 3306
+#         targetPort: 3306


### PR DESCRIPTION
The Bitnami Helm repository (https://charts.bitnami.com/bitnami) is being deprecated. This updates the postgresql and mysql sub-chart dependencies to use the Bitnami legacy archive repository instead.

The sub-charts are marked as deprecated and will be removed in a future release.

Refs: https://github.com/bitnami/charts/issues/35164

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * PostgreSQL and MySQL bundled sub-charts marked deprecated. Legacy archive repositories are no longer actively maintained or security-updated; removal planned in future release.

* **New Features**
  * Added support for connecting to existing PostgreSQL or MySQL deployments using configurable connection URIs.
  * Included development setup documentation for local builds and dependency management.

* **Chores**
  * Chart version bumped to 0.2.58.
  * Updated CI/CD workflows for repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->