### PR TITLE
feat: allow overwriting deployment updateStrategy and configuration parameters

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   {{- if not  .Values.autoscaling.enabled }}
   replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory")}}
   {{- end }}

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -30,6 +30,21 @@
             "description": "The number of OpenFGA server replicas (pods) to deploy",
             "default": 3
         },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -1,5 +1,9 @@
 replicaCount: 3
 
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate: {}
+
 image:
   repository: openfga/openfga
   pullPolicy: Always


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

We configured `OPENFGA_DATASTORE_MIN_OPEN_CONNS=45` and distributed the setting to all three replicas. When restarting the Deployment or doing a rolling upgrade, a fourth pod is started and fails with below error since there are no database connections available anymore.

```
panic: initialize postgres datastore: configure primary db: ping db: failed to connect to `user=openfga database=openfga`:
        10.xxx.xx.xx:5432 (postgresql.example.org): server error: FATAL: remaining connection slots are reserved for roles with privileges of the "pg_use_reserved_connections" role (SQLSTATE 53300)
        10.xxx.xx.xx::5432 (postgresql.example.org): server error: FATAL: no pg_hba.conf entry for host "10.xxx.xx.xx:", user "openfga", database "openfga", no encryption (SQLSTATE 28000)

goroutine 1 [running]:
github.com/openfga/openfga/cmd/run.run(0x31736b72b508?, {0x3ebdc80?, 0x4?, 0x2572720?})
    github.com/openfga/openfga/cmd/run/run.go:401 +0xdd
github.com/spf13/cobra.(*Command).execute(0x31736b72b508, {0x3ebdc80, 0x0, 0x0})
    github.com/spf13/cobra@v1.10.2/command.go:1019 +0xafb
github.com/spf13/cobra.(*Command).ExecuteC(0x31736b72b208)
    github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(0x31736b72b208?)
    github.com/spf13/cobra@v1.10.2/command.go:1071 +0x13
main.main()
    github.com/openfga/openfga/cmd/openfga/main.go:28 +0x10f
```


#### How is it being solved?

Allow the user to set the Deployment strategy and additional configuration parameters like:
*  [maxSurge](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge) that specifies the maximum number of Pods that can be created over the desired number of Pods. 
* [maxUnavailable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable) that specifies the maximum number of Pods that can be unavailable during the update process.

The implementation can be tested by running below commands.

**Overwrite**

```bash
helm template openfga openfga --set updateStrategy.rollingUpdate.maxSurge=0 --set updateStrategy.rollingUpdate.maxUnavailable=1 | grep -5 RollingUpdate
```

```yaml
spec:
  strategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openfga
      app.kubernetes.io/instance: openfga
```

**Default behavior**

```bash
helm template openfga openfga | grep -5 RollingUpdate
```

```yaml
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: openfga
spec:
  strategy:
    rollingUpdate: {}
    type: RollingUpdate
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openfga
      app.kubernetes.io/instance: openfga
```

#### What changes are made to solve it?

Updated the `deployment.yaml` and allowed to overwrite the configuration via `values.yaml`.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: {{ include "openfga.fullname" . }}
  labels:
    {{- include "openfga.labels" . | nindent 4 }}
  {{- with .Values.annotations }}
  annotations:
    {{- toYaml . | nindent 4 }}
  {{- end }}
spec:
  {{- if .Values.updateStrategy }}
  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
  {{- end }}#
  # ...
```

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Deployment update strategy is now fully configurable via Helm chart values. Users can directly specify their preferred strategy type and rolling update parameters through configuration values, enabling customization of how OpenFGA pods are updated during deployments. Rolling update strategy is configured as the default for reliable and seamless service updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->