### PR TITLE
fix(openfga): correct typos and trailing whitespace

### DIFF
--- a/charts/openfga/README.md
+++ b/charts/openfga/README.md
@@ -33,7 +33,7 @@ helm install openfga -f values.yaml oci://ghcr.io/openfga/helm-charts
 
 ## Customization
 
-If you wish to customize the OpenFGA deployment you may supply paremeters such as the ones listed in the [values.yaml](/charts/openfga/values.yaml).
+If you wish to customize the OpenFGA deployment you may supply parameters such as the ones listed in the [values.yaml](/charts/openfga/values.yaml).
 
 ### Installing with Custom Common Labels
 

--- a/charts/openfga/templates/service.yaml
+++ b/charts/openfga/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
 
     {{- if .Values.http.enabled }}
-    - name: http 
+    - name: http
       port: {{ (split ":" .Values.http.addr)._1 }}
       targetPort: http
       protocol: TCP

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -204,7 +204,7 @@
 			        },
 			        "additionalLabels": {
 			            "type": "object",
-			            "description": "additional labels to be added to the serivceMonitor resource",
+			            "description": "additional labels to be added to the serviceMonitor resource",
 			            "default": {}
 			        },
 			        "annotations": {

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -137,7 +137,7 @@ telemetry:
       ##
       enabled: false
 
-      ## @param telemetry.metrics.serviceMonitor.additionalLabels additional labels to be added to the serivceMonitor resource
+      ## @param telemetry.metrics.serviceMonitor.additionalLabels additional labels to be added to the serviceMonitor resource
       ##
       additionalLabels: {}
 


### PR DESCRIPTION
Fix typos and trailing whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling and resource-name references in Helm chart documentation and configuration descriptions.
* **Style**
  * Removed trailing whitespace from the Kubernetes Service template.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->