### PR TITLE
chore: Update openfga to `v1.15.0`

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,8 +3,8 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.3.2
-appVersion: "v1.14.2"
+version: 0.3.3
+appVersion: "v1.15.0"
 
 home: "https://openfga.github.io/helm-charts"
 icon: https://github.com/openfga/community/raw/main/brand-assets/icon/color/openfga-icon-color.svg


### PR DESCRIPTION
## Description
Update OpenFGA to `v1.15.0`.

- `appVersion`: `v1.15.0`
- `version`: `0.3.2` -> `0.3.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to version 0.3.3 with OpenFGA application version v1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->