### PR TITLE
fix: remove dead dependabot entry for charts/benchmark

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,15 +12,6 @@ updates:
           - "*"
 
   - package-ecosystem: "helm"
-    directory: "/charts/benchmark"
-    schedule:
-      interval: "weekly"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "helm"
     directory: "/charts/openfga"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Remove the dependabot entry pointing to `/charts/benchmark`, which no longer exists (the benchmark chart was moved to `archive/benchmark`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation settings for Helm charts.
  * Switched the monitored chart path from one chart to another, while keeping weekly GitHub Actions updates in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->