### PR TITLE
feat: add minReadySeconds and deploymentStrategy passthrough

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.3.10
+version: 0.3.11
 appVersion: "v1.18.1"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -12,6 +12,13 @@ spec:
   {{- if not  .Values.autoscaling.enabled }}
   replicas: {{ ternary 1 .Values.replicaCount (eq .Values.datastore.engine "memory") }}
   {{- end }}
+  {{- if ne .Values.minReadySeconds nil }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "openfga.selectorLabels" . | nindent 6 }}

--- a/charts/openfga/tests/deployment_strategy_test.yaml
+++ b/charts/openfga/tests/deployment_strategy_test.yaml
@@ -1,0 +1,56 @@
+suite: deployment - minReadySeconds and deploymentStrategy
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should not render minReadySeconds when not set
+    asserts:
+      - notExists:
+          path: spec.minReadySeconds
+
+  - it: should render minReadySeconds when set to 0
+    set:
+      minReadySeconds: 0
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 0
+
+  - it: should render minReadySeconds when set to a positive value
+    set:
+      minReadySeconds: 60
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 60
+
+  - it: should not render strategy when deploymentStrategy is not set
+    asserts:
+      - notExists:
+          path: spec.strategy
+
+  - it: should render deploymentStrategy verbatim as spec.strategy
+    set:
+      deploymentStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: should render a Recreate strategy
+    set:
+      deploymentStrategy:
+        type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate

--- a/charts/openfga/tests/deployment_strategy_test.yaml
+++ b/charts/openfga/tests/deployment_strategy_test.yaml
@@ -28,6 +28,13 @@ tests:
       - notExists:
           path: spec.strategy
 
+  - it: should not render strategy when deploymentStrategy is explicitly null
+    set:
+      deploymentStrategy: null
+    asserts:
+      - notExists:
+          path: spec.strategy
+
   - it: should render deploymentStrategy verbatim as spec.strategy
     set:
       deploymentStrategy:

--- a/charts/openfga/tests/deployment_strategy_test.yaml
+++ b/charts/openfga/tests/deployment_strategy_test.yaml
@@ -23,6 +23,26 @@ tests:
           path: spec.minReadySeconds
           value: 60
 
+  - it: should render minReadySeconds at the maximum allowed value
+    set:
+      minReadySeconds: 599
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 599
+
+  - it: should reject a negative minReadySeconds
+    set:
+      minReadySeconds: -1
+    asserts:
+      - failedTemplate: {}
+
+  - it: should reject minReadySeconds of 600 or more
+    set:
+      minReadySeconds: 600
+    asserts:
+      - failedTemplate: {}
+
   - it: should not render strategy when deploymentStrategy is not set
     asserts:
       - notExists:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -35,7 +35,7 @@
             "description": "Minimum number of seconds for which a newly created pod should be ready without any of its containers crashing, for it to be considered available. Defaults to the Kubernetes default (0). For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds"
         },
         "deploymentStrategy": {
-            "type": "object",
+            "type": ["object", "null"],
             "description": "Specifies the strategy used to replace old pods by new ones. Passed through verbatim to the deployment's spec.strategy field. For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy",
             "default": {}
         },

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -30,6 +30,15 @@
             "description": "The number of OpenFGA server replicas (pods) to deploy",
             "default": 3
         },
+        "minReadySeconds": {
+            "type": ["integer", "null"],
+            "description": "Minimum number of seconds for which a newly created pod should be ready without any of its containers crashing, for it to be considered available. Defaults to the Kubernetes default (0). For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds"
+        },
+        "deploymentStrategy": {
+            "type": "object",
+            "description": "Specifies the strategy used to replace old pods by new ones. Passed through verbatim to the deployment's spec.strategy field. For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy",
+            "default": {}
+        },
         "autoscaling": {
             "type": "object",
             "properties": {

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -32,7 +32,9 @@
         },
         "minReadySeconds": {
             "type": ["integer", "null"],
-            "description": "Minimum number of seconds for which a newly created pod should be ready without any of its containers crashing, for it to be considered available. Defaults to the Kubernetes default (0). For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds"
+            "minimum": 0,
+            "maximum": 599,
+            "description": "Minimum number of seconds for which a newly created pod should be ready without any of its containers crashing, for it to be considered available. Must be non-negative and smaller than the deployment's progressDeadlineSeconds (Kubernetes default: 600). Defaults to the Kubernetes default (0). For more information see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds"
         },
         "deploymentStrategy": {
             "type": ["object", "null"],

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 3
 
+minReadySeconds:
+deploymentStrategy: {}
+
 image:
   repository: openfga/openfga
   pullPolicy: Always


### PR DESCRIPTION
## Description

The chart's Deployment currently always uses the Kubernetes default rollout behavior and exposes no knobs to control it. Because OpenFGA pods typically become Ready within seconds, a rolling update replaces every replica almost simultaneously — so all pods start with cold in-memory caches (check query cache, iterator cache) at the same moment, causing a datastore load spike right after every deployment.

This PR exposes two standard Deployment fields as chart values:

- **`minReadySeconds`** (default: unset) — rendered as `spec.minReadySeconds` when set. Lets operators space out pod replacement so each new pod serves (and warms its cache with) live traffic before the next pod is replaced, keeping at most one cold-cache pod in rotation at a time.
- **`deploymentStrategy`** (default: `{}`) — passed through verbatim as `spec.strategy` when set. Lets operators tune `maxSurge`/`maxUnavailable` or use `Recreate`.

Both are optional and omitted by default, so rendered manifests are **unchanged for existing users**.

## Changes

- `templates/deployment.yaml`: render `minReadySeconds` (guarded with `ne ... nil` so an explicit `0` renders, matching the existing falsy-numeric handling) and `strategy`
- `values.yaml` + `values.schema.json`: document the new values (`minReadySeconds` as `integer|null`, `deploymentStrategy` as object)
- `tests/deployment_strategy_test.yaml`: helm-unittest coverage — unset (omitted), `0`, positive value, RollingUpdate passthrough, Recreate
- `Chart.yaml`: bump version to 0.3.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real life implications
For our usage, we're seeing connection storm at the time of deployment. To be fair, the same could happen under extreme heavy load, where every single call misses the cache. So this is supporting cost-saving, where we rightsize the deployment based on actual usage, but that "actual usage" becomes worst case during deployments.
`deploymentStrategy` is only added as due-diligence, for future possible deployment tweaks. Let me know if we want to omit that for now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart options for configuring minimum ready time and deployment strategy, including RollingUpdate and Recreate modes.
  * Deployment settings are applied only when configured, preserving existing defaults.

* **Documentation**
  * Updated the chart version to 0.3.15.

* **Tests**
  * Added coverage for deployment strategy and minimum ready time configurations, including zero-value and omitted settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
