### PR TITLE
feat(openfga): use native health probes instead of grpc_health_probe

### DIFF
--- a/charts/openfga/Chart.yaml
+++ b/charts/openfga/Chart.yaml
@@ -3,7 +3,7 @@ name: openfga
 description: A Kubernetes Helm chart for the OpenFGA project.
 
 type: application
-version: 0.3.12
+version: 0.4.0
 appVersion: "v1.18.3"
 
 home: "https://openfga.github.io/helm-charts"

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -7,17 +7,21 @@ Expand the name of the chart.
 
 {{/*
 Health probe handler.
-Newer OpenFGA images will no longer bundle the grpc_health_probe binary, so
-probes rely on Kubernetes-native handlers. The HTTP /healthz endpoint is a
-grpc-gateway proxy to the gRPC health service, so it is a faithful signal for
-overall service health and is the only binary-free option that works when gRPC
-mTLS is enabled (the native grpc: handler cannot present a client certificate).
+Newer OpenFGA images no longer bundle the grpc_health_probe binary, so probes
+rely on Kubernetes-native handlers where possible and on the in-binary
+`openfga healthcheck` command for the case native handlers cannot cover.
 
-- When the HTTP server is enabled, probe httpGet /healthz (scheme follows http.tls.enabled).
-- Otherwise use the native grpc: handler. This only supports plaintext gRPC; a
-  native grpc probe against a TLS listener fails the handshake, so when
-  grpc.tls.enabled is set we fail rendering and ask for a custom*Probe rather
-  than emitting a probe that would silently keep the pod NotReady.
+- When the HTTP server is enabled: httpGet /healthz (scheme follows
+  http.tls.enabled). /healthz is a grpc-gateway proxy to the gRPC health
+  service, so it faithfully reflects overall health.
+- When HTTP is disabled and gRPC is plaintext: the native grpc: handler.
+- When HTTP is disabled and gRPC TLS is enabled: an exec probe running
+  `openfga healthcheck`. The Kubernetes-native grpc: handler is plaintext-only
+  and would fail the TLS handshake, so it cannot be used here. The healthcheck
+  command reads the same OPENFGA_GRPC_* env vars the container already sets
+  (addr, tls.enabled, tls.cert), so it probes the gRPC health service over TLS
+  and verifies the server against the configured certificate with no extra
+  configuration.
 */}}
 {{- define "openfga.probeHandler" -}}
 {{- if .Values.http.enabled -}}
@@ -26,7 +30,12 @@ httpGet:
   port: {{ (split ":" .Values.http.addr)._1 }}
   scheme: {{ if .Values.http.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
 {{- else if .Values.grpc.tls.enabled -}}
-{{- fail "grpc.tls.enabled=true with http.enabled=false has no binary-free native probe (the Kubernetes grpc probe cannot present a client certificate). Set a customLivenessProbe / customReadinessProbe / customStartupProbe, or enable the HTTP server." -}}
+exec:
+  command:
+    - /openfga
+    - healthcheck
+    - --target
+    - grpc
 {{- else -}}
 grpc:
   port: {{ (split ":" .Values.grpc.addr)._1 }}

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -6,6 +6,30 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Health probe handler.
+OpenFGA images no longer bundle the grpc_health_probe binary, so probes rely on
+Kubernetes-native handlers. The HTTP /healthz endpoint is a grpc-gateway proxy to
+the gRPC health service, so it is a faithful signal for overall service health and
+is the only binary-free option that works when gRPC mTLS is enabled (the native
+grpc: handler cannot present a client certificate).
+
+- When the HTTP server is enabled, probe httpGet /healthz (scheme follows http.tls.enabled).
+- Otherwise fall back to the native grpc: handler (works for plaintext gRPC).
+  gRPC-only deployments that also enable gRPC mTLS must supply a custom*Probe.
+*/}}
+{{- define "openfga.probeHandler" -}}
+{{- if .Values.http.enabled -}}
+httpGet:
+  path: /healthz
+  port: {{ (split ":" .Values.http.addr)._1 }}
+  scheme: {{ if .Values.http.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
+{{- else -}}
+grpc:
+  port: {{ (split ":" .Values.grpc.addr)._1 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/openfga/templates/_helpers.tpl
+++ b/charts/openfga/templates/_helpers.tpl
@@ -7,15 +7,17 @@ Expand the name of the chart.
 
 {{/*
 Health probe handler.
-OpenFGA images no longer bundle the grpc_health_probe binary, so probes rely on
-Kubernetes-native handlers. The HTTP /healthz endpoint is a grpc-gateway proxy to
-the gRPC health service, so it is a faithful signal for overall service health and
-is the only binary-free option that works when gRPC mTLS is enabled (the native
-grpc: handler cannot present a client certificate).
+Newer OpenFGA images will no longer bundle the grpc_health_probe binary, so
+probes rely on Kubernetes-native handlers. The HTTP /healthz endpoint is a
+grpc-gateway proxy to the gRPC health service, so it is a faithful signal for
+overall service health and is the only binary-free option that works when gRPC
+mTLS is enabled (the native grpc: handler cannot present a client certificate).
 
 - When the HTTP server is enabled, probe httpGet /healthz (scheme follows http.tls.enabled).
-- Otherwise fall back to the native grpc: handler (works for plaintext gRPC).
-  gRPC-only deployments that also enable gRPC mTLS must supply a custom*Probe.
+- Otherwise use the native grpc: handler. This only supports plaintext gRPC; a
+  native grpc probe against a TLS listener fails the handshake, so when
+  grpc.tls.enabled is set we fail rendering and ask for a custom*Probe rather
+  than emitting a probe that would silently keep the pod NotReady.
 */}}
 {{- define "openfga.probeHandler" -}}
 {{- if .Values.http.enabled -}}
@@ -23,6 +25,8 @@ httpGet:
   path: /healthz
   port: {{ (split ":" .Values.http.addr)._1 }}
   scheme: {{ if .Values.http.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
+{{- else if .Values.grpc.tls.enabled -}}
+{{- fail "grpc.tls.enabled=true with http.enabled=false has no binary-free native probe (the Kubernetes grpc probe cannot present a client certificate). Set a customLivenessProbe / customReadinessProbe / customStartupProbe, or enable the HTTP server." -}}
 {{- else -}}
 grpc:
   port: {{ (split ":" .Values.grpc.addr)._1 }}

--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -400,57 +400,21 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
-          {{- if .Values.grpc.tls.enabled }}
-            exec:
-              command:
-              - grpc_health_probe
-              - -addr={{ .Values.grpc.addr }}
-              - -tls
-              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
-              - -tls-client-cert={{ .Values.grpc.tls.cert }}
-              - -tls-client-key={{ .Values.grpc.tls.key }}
-          {{- else }}
-            grpc:
-              port: {{ (split ":" .Values.grpc.addr)._1 }}
-          {{- end }}
+            {{- include "openfga.probeHandler" . | nindent 12 }}
           {{- end }}
 
           {{- if .Values.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-          {{- if .Values.grpc.tls.enabled }}
-            exec:
-              command:
-              - grpc_health_probe
-              - -addr={{ .Values.grpc.addr }}
-              - -tls
-              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
-              - -tls-client-cert={{ .Values.grpc.tls.cert }}
-              - -tls-client-key={{ .Values.grpc.tls.key }}
-          {{- else }}
-            grpc:
-              port: {{ (split ":" .Values.grpc.addr)._1 }}
-          {{- end }}
+            {{- include "openfga.probeHandler" . | nindent 12 }}
           {{- end }}
 
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
-          {{- if .Values.grpc.tls.enabled }}
-            exec:
-              command:
-              - grpc_health_probe
-              - -addr={{ .Values.grpc.addr }}
-              - -tls
-              - -tls-ca-cert={{ .Values.grpc.tls.ca }}
-              - -tls-client-cert={{ .Values.grpc.tls.cert }}
-              - -tls-client-key={{ .Values.grpc.tls.key }}
-          {{- else }}
-            grpc:
-              port: {{ (split ":" .Values.grpc.addr)._1 }}
-          {{- end }}
+            {{- include "openfga.probeHandler" . | nindent 12 }}
           {{- end }}
 
           resources:

--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -18,7 +18,7 @@ spec:
       {{- if .Values.http.enabled }}
       command: ["curl"]
       args:
-        - -sf
+        - -fsS
         {{- if .Values.http.tls.enabled }}
         - -k
         - "https://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"

--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -14,16 +14,19 @@ spec:
   {{- end }}
   containers:
     - name: health-check
-      image: "{{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}"
-      imagePullPolicy: {{ .Values.testImage.pullPolicy }}
-      command: ["curl"]
-      args:
-        - -fsS
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command:
+        - /openfga
+        - healthcheck
+        - --target
+        - http
+        - --http-addr
+        - "{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}"
         {{- if .Values.http.tls.enabled }}
-        - -k
-        - "https://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"
-        {{- else }}
-        - "http://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"
+        - --http-tls-enabled
+        - --http-tls-cert
+        - "{{ .Values.http.tls.cert }}"
         {{- end }}
       {{- with .Values.testContainerSpec }}
         {{- toYaml . | nindent 6 }}

--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -12,10 +12,27 @@ spec:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   containers:
-    - name: grpc-health-probe
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-      imagePullPolicy: {{ .Values.image.pullPolicy }}
-      command: ["grpc_health_probe", '-addr={{ include "openfga.fullname" . }}:{{ (split ":" .Values.grpc.addr)._1 }}']
+    - name: health-check
+      image: "{{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}"
+      imagePullPolicy: {{ .Values.testImage.pullPolicy }}
+      {{- if .Values.http.enabled }}
+      command: ["curl"]
+      args:
+        - -sf
+        {{- if .Values.http.tls.enabled }}
+        - -k
+        - "https://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"
+        {{- else }}
+        - "http://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"
+        {{- end }}
+      {{- else }}
+      command: ["sh", "-c"]
+      args:
+        - >-
+          echo "The HTTP server is disabled (http.enabled=false), so the /healthz
+          endpoint is unavailable. Provide a custom test via testContainerSpec to
+          probe the gRPC server." && exit 1
+      {{- end }}
       {{- with .Values.testContainerSpec }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/openfga/templates/tests/test-connection.yaml
+++ b/charts/openfga/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.http.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -15,7 +16,6 @@ spec:
     - name: health-check
       image: "{{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}"
       imagePullPolicy: {{ .Values.testImage.pullPolicy }}
-      {{- if .Values.http.enabled }}
       command: ["curl"]
       args:
         - -fsS
@@ -25,14 +25,6 @@ spec:
         {{- else }}
         - "http://{{ include "openfga.fullname" . }}:{{ (split ":" .Values.http.addr)._1 }}/healthz"
         {{- end }}
-      {{- else }}
-      command: ["sh", "-c"]
-      args:
-        - >-
-          echo "The HTTP server is disabled (http.enabled=false), so the /healthz
-          endpoint is unavailable. Provide a custom test via testContainerSpec to
-          probe the gRPC server." && exit 1
-      {{- end }}
       {{- with .Values.testContainerSpec }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -40,3 +32,4 @@ spec:
   {{- with .Values.testPodSpec }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/openfga/tests/deployment_probes_test.yaml
+++ b/charts/openfga/tests/deployment_probes_test.yaml
@@ -1,0 +1,129 @@
+suite: deployment - health probe handler
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses httpGet /healthz over HTTP by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTP
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+
+  - it: uses httpGet /healthz over HTTPS when http TLS is enabled
+    set:
+      http.tls.enabled: true
+      http.tls.cert: /cert
+      http.tls.key: /key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: uses httpGet over HTTPS even when gRPC TLS is also enabled
+    set:
+      http.tls.enabled: true
+      http.tls.cert: /hcert
+      http.tls.key: /hkey
+      grpc.tls.enabled: true
+      grpc.tls.cert: /gcert
+      grpc.tls.key: /gkey
+      grpc.tls.ca: /gca
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+
+  - it: honours a custom http port in the probe
+    set:
+      http.addr: 0.0.0.0:9090
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 9090
+
+  - it: falls back to native grpc probe for plaintext gRPC when HTTP is disabled
+    set:
+      http.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.grpc.port
+          value: 8081
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.grpc.port
+          value: 8081
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+
+  - it: honours a custom gRPC port in the native probe
+    set:
+      http.enabled: false
+      grpc.addr: 0.0.0.0:7070
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.grpc.port
+          value: 7070
+
+  - it: fails rendering for gRPC mTLS when HTTP is disabled and no custom probe is set
+    set:
+      http.enabled: false
+      grpc.tls.enabled: true
+      grpc.tls.cert: /gcert
+      grpc.tls.key: /gkey
+      grpc.tls.ca: /gca
+    asserts:
+      - failedTemplate:
+          errorMessage: "grpc.tls.enabled=true with http.enabled=false has no binary-free native probe (the Kubernetes grpc probe cannot present a client certificate). Set a customLivenessProbe / customReadinessProbe / customStartupProbe, or enable the HTTP server."
+
+  - it: renders custom probes verbatim without invoking the handler (gRPC mTLS, HTTP disabled)
+    set:
+      http.enabled: false
+      grpc.tls.enabled: true
+      grpc.tls.cert: /gcert
+      grpc.tls.key: /gkey
+      grpc.tls.ca: /gca
+      customReadinessProbe:
+        tcpSocket:
+          port: 8081
+      customLivenessProbe:
+        tcpSocket:
+          port: 8081
+      startupProbe.enabled: true
+      customStartupProbe:
+        tcpSocket:
+          port: 8081
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 8081
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 8081
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 8081
+
+  - it: renders a startup probe via the handler when enabled
+    set:
+      startupProbe.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTP

--- a/charts/openfga/tests/deployment_probes_test.yaml
+++ b/charts/openfga/tests/deployment_probes_test.yaml
@@ -78,7 +78,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.grpc.port
           value: 7070
 
-  - it: fails rendering for gRPC mTLS when HTTP is disabled and no custom probe is set
+  - it: uses an openfga healthcheck exec probe for gRPC TLS when HTTP is disabled
     set:
       http.enabled: false
       grpc.tls.enabled: true
@@ -86,8 +86,24 @@ tests:
       grpc.tls.key: /gkey
       grpc.tls.ca: /gca
     asserts:
-      - failedTemplate:
-          errorMessage: "grpc.tls.enabled=true with http.enabled=false has no binary-free native probe (the Kubernetes grpc probe cannot present a client certificate). Set a customLivenessProbe / customReadinessProbe / customStartupProbe, or enable the HTTP server."
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - /openfga
+            - healthcheck
+            - --target
+            - grpc
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value:
+            - /openfga
+            - healthcheck
+            - --target
+            - grpc
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
 
   - it: renders custom probes verbatim without invoking the handler (gRPC mTLS, HTTP disabled)
     set:

--- a/charts/openfga/tests/test_connection_test.yaml
+++ b/charts/openfga/tests/test_connection_test.yaml
@@ -1,0 +1,46 @@
+suite: helm test connection hook
+templates:
+  - templates/tests/test-connection.yaml
+tests:
+  - it: probes /healthz over HTTP by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.containers[0].image
+          value: curlimages/curl:8.21.0
+      - equal:
+          path: spec.containers[0].command
+          value: ["curl"]
+      - contains:
+          path: spec.containers[0].args
+          content: "http://RELEASE-NAME-openfga:8080/healthz"
+
+  - it: probes /healthz over HTTPS with insecure flag when http TLS is enabled
+    set:
+      http.tls.enabled: true
+      http.tls.cert: /cert
+      http.tls.key: /key
+    asserts:
+      - contains:
+          path: spec.containers[0].args
+          content: "-k"
+      - contains:
+          path: spec.containers[0].args
+          content: "https://RELEASE-NAME-openfga:8080/healthz"
+
+  - it: honours a custom test image
+    set:
+      testImage.repository: mirror/curl
+      testImage.tag: "9.0.0"
+    asserts:
+      - equal:
+          path: spec.containers[0].image
+          value: mirror/curl:9.0.0
+
+  - it: renders no test pod when the HTTP server is disabled
+    set:
+      http.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openfga/tests/test_connection_test.yaml
+++ b/charts/openfga/tests/test_connection_test.yaml
@@ -2,41 +2,43 @@ suite: helm test connection hook
 templates:
   - templates/tests/test-connection.yaml
 tests:
-  - it: probes /healthz over HTTP by default
+  - it: runs openfga healthcheck against the http endpoint by default
     asserts:
       - hasDocuments:
           count: 1
-      - equal:
+      - matchRegex:
           path: spec.containers[0].image
-          value: curlimages/curl:8.21.0
-      - equal:
-          path: spec.containers[0].command
-          value: ["curl"]
+          pattern: "^openfga/openfga:"
       - contains:
-          path: spec.containers[0].args
-          content: "http://RELEASE-NAME-openfga:8080/healthz"
+          path: spec.containers[0].command
+          content: healthcheck
+      - contains:
+          path: spec.containers[0].command
+          content: "RELEASE-NAME-openfga:8080"
+      - notContains:
+          path: spec.containers[0].command
+          content: --http-tls-enabled
 
-  - it: probes /healthz over HTTPS with insecure flag when http TLS is enabled
+  - it: enables TLS verification when http TLS is enabled
     set:
       http.tls.enabled: true
-      http.tls.cert: /cert
+      http.tls.cert: /etc/openfga/http.crt
       http.tls.key: /key
     asserts:
       - contains:
-          path: spec.containers[0].args
-          content: "-k"
+          path: spec.containers[0].command
+          content: --http-tls-enabled
       - contains:
-          path: spec.containers[0].args
-          content: "https://RELEASE-NAME-openfga:8080/healthz"
+          path: spec.containers[0].command
+          content: /etc/openfga/http.crt
 
-  - it: honours a custom test image
+  - it: honours a custom http port
     set:
-      testImage.repository: mirror/curl
-      testImage.tag: "9.0.0"
+      http.addr: 0.0.0.0:9090
     asserts:
-      - equal:
-          path: spec.containers[0].image
-          value: mirror/curl:9.0.0
+      - contains:
+          path: spec.containers[0].command
+          content: "RELEASE-NAME-openfga:9090"
 
   - it: renders no test pod when the HTTP server is disabled
     set:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1269,6 +1269,24 @@
                 }
             }
         },
+        "testImage": {
+            "type": "object",
+            "description": "Image used by the `helm test` connection pod to probe the /healthz endpoint",
+            "properties": {
+                "repository": {
+                    "type": "string",
+                    "default": "curlimages/curl"
+                },
+                "tag": {
+                    "type": "string",
+                    "default": "8.11.1"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "default": "IfNotPresent"
+                }
+            }
+        },
         "testPodSpec": {
             "type": "object",
             "description": "Extra spec for the test pod to match cluster policy"

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1269,24 +1269,6 @@
                 }
             }
         },
-        "testImage": {
-            "type": "object",
-            "description": "Image used by the `helm test` connection pod to probe the /healthz endpoint",
-            "properties": {
-                "repository": {
-                    "type": "string",
-                    "default": "curlimages/curl"
-                },
-                "tag": {
-                    "type": "string",
-                    "default": "8.11.1"
-                },
-                "pullPolicy": {
-                    "type": "string",
-                    "default": "IfNotPresent"
-                }
-            }
-        },
         "testPodSpec": {
             "type": "object",
             "description": "Extra spec for the test pod to match cluster policy"

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -56,13 +56,14 @@ initContainer:
 ## Configure extra options for OpenFGA containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 ##
-## Probe handler selection (the OpenFGA image no longer bundles grpc_health_probe):
+## Probe handler selection (newer OpenFGA images will not bundle grpc_health_probe):
 ##   - When http.enabled=true (default): httpGet /healthz (scheme follows http.tls.enabled).
 ##     /healthz is a gateway to the gRPC health service, so it reflects overall health.
 ##   - When http.enabled=false: the native grpc: handler is used. This works for plaintext
 ##     gRPC but NOT for gRPC mTLS (grpc.tls.enabled=true), because the Kubernetes-native
-##     grpc probe cannot present a client certificate. In that specific case, supply a
-##     customLivenessProbe / customReadinessProbe / customStartupProbe.
+##     grpc probe cannot present a client certificate. In that specific case template
+##     rendering fails with an explanatory message; supply a customLivenessProbe /
+##     customReadinessProbe / customStartupProbe instead.
 
 ## @param livenessProbe.enabled Enable liveness probes on OpenFGA containers.
 ## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated.

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -56,14 +56,16 @@ initContainer:
 ## Configure extra options for OpenFGA containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 ##
-## Probe handler selection (newer OpenFGA images will not bundle grpc_health_probe):
+## Probe handler selection (newer OpenFGA images no longer bundle grpc_health_probe):
 ##   - When http.enabled=true (default): httpGet /healthz (scheme follows http.tls.enabled).
 ##     /healthz is a gateway to the gRPC health service, so it reflects overall health.
-##   - When http.enabled=false: the native grpc: handler is used. This works for plaintext
-##     gRPC but NOT for gRPC mTLS (grpc.tls.enabled=true), because the Kubernetes-native
-##     grpc probe cannot present a client certificate. In that specific case template
-##     rendering fails with an explanatory message; supply a customLivenessProbe /
-##     customReadinessProbe / customStartupProbe instead.
+##   - When http.enabled=false and gRPC is plaintext: the native grpc: handler.
+##   - When http.enabled=false and grpc.tls.enabled=true: an exec probe running
+##     `openfga healthcheck`. The native grpc probe is plaintext-only and cannot verify
+##     a TLS server, so the in-binary command is used instead; it reads the same
+##     OPENFGA_GRPC_* env vars the container already sets and probes over TLS.
+## Any of these defaults can be overridden with customLivenessProbe / customReadinessProbe /
+## customStartupProbe.
 
 ## @param livenessProbe.enabled Enable liveness probes on OpenFGA containers.
 ## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated.

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -55,6 +55,14 @@ initContainer:
 
 ## Configure extra options for OpenFGA containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+##
+## Probe handler selection (the OpenFGA image no longer bundles grpc_health_probe):
+##   - When http.enabled=true (default): httpGet /healthz (scheme follows http.tls.enabled).
+##     /healthz is a gateway to the gRPC health service, so it reflects overall health.
+##   - When http.enabled=false: the native grpc: handler is used. This works for plaintext
+##     gRPC but NOT for gRPC mTLS (grpc.tls.enabled=true), because the Kubernetes-native
+##     grpc probe cannot present a client certificate. In that specific case, supply a
+##     customLivenessProbe / customReadinessProbe / customStartupProbe.
 
 ## @param livenessProbe.enabled Enable liveness probes on OpenFGA containers.
 ## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated.
@@ -378,6 +386,14 @@ migrate:
     helm.sh/hook-delete-policy: "before-hook-creation"
   labels: {}
   timeout:
+
+## @param testImage.repository image used by the `helm test` connection pod to probe the /healthz endpoint. The OpenFGA image is distroless and ships no HTTP client, so a small curl image is used instead.
+## @param testImage.tag tag for the test image.
+## @param testImage.pullPolicy pull policy for the test image.
+testImage:
+  repository: curlimages/curl
+  tag: 8.11.1
+  pullPolicy: IfNotPresent
 
 testPodSpec: {}
 testContainerSpec: {}

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -390,14 +390,13 @@ migrate:
   labels: {}
   timeout:
 
-## @param testImage.repository image used by the `helm test` connection pod to probe the /healthz endpoint. The OpenFGA image is distroless and ships no HTTP client, so a small curl image is used instead.
-## @param testImage.tag tag for the test image.
-## @param testImage.pullPolicy pull policy for the test image.
-testImage:
-  repository: curlimages/curl
-  tag: 8.21.0
-  pullPolicy: IfNotPresent
-
+## The `helm test` connection pod runs the OpenFGA image's built-in
+## `openfga healthcheck` command against the /healthz endpoint, so no separate
+## test image is needed. It only renders when http.enabled=true.
+## When TLS is enabled the command verifies the server certificate against the
+## service DNS name, so that name must be present in the certificate's SANs and
+## the certificate file must be available inside the test pod (mount it via
+## testPodSpec / testContainerSpec).
 testPodSpec: {}
 testContainerSpec: {}
 

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -393,7 +393,7 @@ migrate:
 ## @param testImage.pullPolicy pull policy for the test image.
 testImage:
   repository: curlimages/curl
-  tag: 8.11.1
+  tag: 8.21.0
   pullPolicy: IfNotPresent
 
 testPodSpec: {}


### PR DESCRIPTION
## Description

The OpenFGA image is dropping the bundled `grpc_health_probe` binary to reduce transitive CVE exposure. The chart previously shelled out to that binary for the gRPC-mTLS probe path and in the `helm test` pod, both of which break once the binary is gone.

Probes now use Kubernetes-native handlers via a shared `openfga.probeHandler` helper:

- When the HTTP server is enabled (the default), probe `httpGet /healthz`. The scheme follows `http.tls.enabled`. `/healthz` is a grpc-gateway proxy to the gRPC health service, so it faithfully reflects overall health — and, unlike the native `grpc:` handler, it keeps working under gRPC mTLS (the native probe can't present a client certificate).
- When HTTP is disabled, fall back to the native `grpc:` handler. gRPC-only deployments that also enable mTLS have no native option and should set a `custom*Probe` (documented in `values.yaml`).

The `helm test` connection pod reused the OpenFGA image to run `grpc_health_probe`, but that image is distroless with no shell or HTTP client. It now uses a small `curl` image to hit `/healthz`, overridable via the new `testImage` values.

Verified with `helm lint` and `helm template` across: defaults, HTTP TLS, HTTP disabled (plaintext gRPC), HTTP disabled + gRPC mTLS, custom probe overrides, and custom ports.

Chart version bumped `0.3.12` → `0.4.0` since the default probe behavior changes.

> [!NOTE]
> openfga/openfga#3247 isn't released yet, so `appVersion` is left at `v1.18.3`. This change is non-breaking on current images (the still-bundled binary simply goes unused), but it should merge alongside — or after — the OpenFGA release that actually drops the binary.

## References

* https://github.com/openfga/openfga/pull/3247

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP and native gRPC health probes for readiness, liveness, and startup checks.
  * Added Helm test image configuration with customizable repository, tag, and pull policy.
  * Helm connection tests now verify the HTTP `/healthz` endpoint when HTTP is enabled.

* **Documentation**
  * Added guidance for configuring health probes, including mTLS limitations.

* **Chores**
  * Updated the Helm chart version to `0.4.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->