### PR TITLE
fix: allow string values in extraObjects schema

### DIFF
--- a/charts/openfga/tests/extra_objects_test.yaml
+++ b/charts/openfga/tests/extra_objects_test.yaml
@@ -1,0 +1,18 @@
+suite: extra objects
+templates:
+  - templates/extra-manifests.yaml
+tests:
+  - it: should render a string manifest
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: string-manifest
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: string-manifest

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -1281,7 +1281,10 @@
         "extraObjects": {
             "type": "array",
             "items": {
-                "type": "object"
+                "type": [
+                    "string",
+                    "object"
+                ]
             },
             "default": []
         },


### PR DESCRIPTION
## Summary

- Allow `extraObjects` schema items to be strings or objects
- Add a regression test for string manifest rendering

## Why

The template already supports string values, but schema validation rejects them before rendering. This blocks `--set-file` and similar workflows. Existing object values are unchanged.

Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining additional chart resources as either YAML strings or structured objects.
  * Added coverage for rendering extra resources, including ConfigMaps, with their expected metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->